### PR TITLE
Update python version used in github workflows

### DIFF
--- a/.github/workflows/cmake-macos.yaml
+++ b/.github/workflows/cmake-macos.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [macos-11]
         target: [Debug, Release, RelWithDebInfo]
-        python: ["3.10"]
+        python: ["3.11"]
         suite: [gcc]
         suiteVersion: ["11"]
         include:

--- a/.github/workflows/cmake-ubuntu.yaml
+++ b/.github/workflows/cmake-ubuntu.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         target: [Debug, Release, RelWithDebInfo]
-        python: ["3.10"]
+        python: ["3.11"]
         suite: [gcc]
         suiteVersion: ["11"]
         include:


### PR DESCRIPTION
It seems that after the upgrade of rev. 5d57d1b, the mac os action has been failing (python not found by cmake).