### PR TITLE
Fix factories destructors

### DIFF
--- a/.github/workflows/cmake-macos.yaml
+++ b/.github/workflows/cmake-macos.yaml
@@ -168,5 +168,13 @@ jobs:
           cd ${{runner.temp}}/build
           echo " -- testing mito"
           ctest --output-on-failure -E postgres.ext
+      
+      - name: create artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: mito_build_${{matrix.target}}
+          path: ${{runner.temp}}/build
+          retention-days: 7
 
 # end of file

--- a/.github/workflows/cmake-macos.yaml
+++ b/.github/workflows/cmake-macos.yaml
@@ -47,10 +47,14 @@ jobs:
           python3 -m pip install --upgrade pip
           pip3 install distro numpy pybind11 pytest vtk
       
+      - name: checkout gtest
+        uses: actions/checkout@v3
+        with:
+          repository: google/googletest
+          path: googletest
+      
       - name: install gtest
         run: |
-          echo " -- cloning gtest"
-          git clone https://github.com/google/googletest
           echo " -- switching to the build directory"
           cd ${{runner.temp}}
           mkdir build
@@ -68,10 +72,12 @@ jobs:
           cc: ${{matrix.cc}}-${{matrix.suiteVersion}}
           cxx: ${{matrix.cxx}}-${{matrix.suiteVersion}}
       
-      - name: pyre setup
-        run: |
-          echo " -- cloning pyre"
-          git clone https://github.com/pyre/pyre
+      - name: checkout pyre
+        uses: actions/checkout@v3
+        with:
+          repository: pyre/pyre
+          fetch-depth: 0
+          path: pyre
 
       - name: build pyre
         run: |
@@ -133,17 +139,11 @@ jobs:
         env:
           pythonVersion: ${{matrix.python}}
 
-      - name: clone mito
-        run: |
-          echo " -- cloning mito"
-          git clone https://github.com/mitadel/mito
-
       - name: checkout mito
-        run: |
-          echo " -- switching to the mito home directory"
-          cd mito
-          echo " -- checking out the correct ref"
-          git checkout ${{github.event.pull_request.head.sha}}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{github.event.pull_request.head.sha}}
+          path: mito
 
       - name: build mito
         run: |

--- a/.github/workflows/cmake-ubuntu.yaml
+++ b/.github/workflows/cmake-ubuntu.yaml
@@ -52,10 +52,12 @@ jobs:
           python3 -m pip install --upgrade pip
           pip3 install distro numpy pybind11 pytest vtk
 
-      - name: pyre setup
-        run: |
-          echo " -- cloning pyre"
-          git clone https://github.com/pyre/pyre
+      - name: checkout pyre
+        uses: actions/checkout@v3
+        with:
+          repository: pyre/pyre
+          fetch-depth: 0
+          path: pyre
 
       - name: build pyre
         run: |
@@ -124,18 +126,12 @@ jobs:
 
         env:
           pythonVersion: ${{matrix.python}}
-      
-      - name: clone mito
-        run: |
-          echo " -- cloning mito"
-          git clone https://github.com/mitadel/mito
 
       - name: checkout mito
-        run: |
-          echo " -- switching to the mito home directory"
-          cd mito
-          echo " -- checking out the correct ref"
-          git checkout ${{github.event.pull_request.head.sha}}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{github.event.pull_request.head.sha}}
+          path: mito
 
       - name: build mito
         run: |

--- a/.github/workflows/cmake-ubuntu.yaml
+++ b/.github/workflows/cmake-ubuntu.yaml
@@ -160,5 +160,13 @@ jobs:
           cd ${{runner.temp}}/build
           echo " -- testing mito"
           ctest --output-on-failure -E postgres.ext
+      
+      - name: create artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: mito_build_${{matrix.target}}
+          path: ${{runner.temp}}/build
+          retention-days: 7
 
 # end of file

--- a/.github/workflows/cmake-ubuntu.yaml
+++ b/.github/workflows/cmake-ubuntu.yaml
@@ -6,8 +6,9 @@ on:
     branches:
       - 'main'
   pull_request:
-  
+  workflow_dispatch:
 
+  
 jobs:
   # build and test the ref that launched this action
   build:

--- a/extensions/mito/mito.cc
+++ b/extensions/mito/mito.cc
@@ -130,7 +130,7 @@ PYBIND11_MODULE(mito, m)
                 // create an input stream
                 auto filestream = std::ifstream(filename);
                 // read the mesh
-                auto mesh = new mito::mesh::mesh_t(
+                auto mesh = new mito::mesh::mesh_t<mito::topology::triangle_t, 2>(
                     mito::io::summit::reader<mito::topology::triangle_t, 2>(filestream, geometry));
                 // instantiate
                 return new mito::manifolds::manifold_t<mito::topology::triangle_t, 2>(*mesh);

--- a/lib/mito/fem/QuadratureField.h
+++ b/lib/mito/fem/QuadratureField.h
@@ -101,8 +101,8 @@ namespace mito::fem {
         }
 
         // support for ranged for loops (wrapping grid)
-        inline const auto begin() const { return _grid.cbegin(); }
-        inline const auto end() const { return _grid.cend(); }
+        inline auto begin() const { return _grid.cbegin(); }
+        inline auto end() const { return _grid.cend(); }
         inline auto begin() { return _grid.begin(); }
         inline auto end() { return _grid.end(); }
 

--- a/lib/mito/geometry/Geometry.h
+++ b/lib/mito/geometry/Geometry.h
@@ -25,15 +25,14 @@ namespace mito::geometry {
         ~Geometry() {}
 
       public:
-        // TOFIX: not sure I like that this function returns a vertex and not a node
         // register {vertex}-{point} relation as a new node
-        inline auto node(const vertex_t & vertex, const point_t<D> & point) -> const vertex_t &
+        inline auto node(const vertex_t & vertex, const point_t<D> & point) -> void
         {
             // register the node with the geometry
             _nodes.emplace(node_t<D>(vertex, point));
 
-            // return a reference to the newly emplaced node
-            return vertex;
+            // all done
+            return;
         }
 
         // instantiate a new vertex and a new point at {coord} and bind them into a node

--- a/lib/mito/geometry/Point.h
+++ b/lib/mito/geometry/Point.h
@@ -16,6 +16,18 @@ namespace mito::geometry {
 
         ~Point() override {}
 
+        // delete copy constructor
+        Point(const Point &) = delete;
+
+        // delete move constructor
+        Point(Point &&) = delete;
+
+        // delete assignment operator
+        Point & operator=(const Point &) = delete;
+
+        // delete move assignment operator
+        Point & operator=(Point &&) = delete;
+
       public:
         // get the coordinates of the point
         auto coordinates() const -> const vector_t<D> & { return _coordinates; }

--- a/lib/mito/geometry/PointCloud.h
+++ b/lib/mito/geometry/PointCloud.h
@@ -21,7 +21,14 @@ namespace mito::geometry {
         void operator=(const PointCloud<D> &) = delete;
 
         // destructor
-        ~PointCloud() {}
+        ~PointCloud()
+        {
+            if (_cloud.size() > 0) {
+                for (const auto & point : _cloud) {
+                    point->~Point<D>();
+                }
+            }
+        }
 
       public:
         auto print() const -> void

--- a/lib/mito/io/summit/reader.h
+++ b/lib/mito/io/summit/reader.h
@@ -281,7 +281,7 @@ namespace mito::io::summit {
         assert(vertices.size() == static_cast<size_t>(N_vertices));
 
         // sanity check: the number of cells of highest dimension in the map is N_cells
-        assert(mesh.template nCells() == N_cells);
+        assert(mesh.nCells() == N_cells);
 
         // sanity check: run sanity check for all mesh simplices in cascade
         assert(mesh.sanityCheck());

--- a/lib/mito/manifolds/Manifold.h
+++ b/lib/mito/manifolds/Manifold.h
@@ -51,13 +51,13 @@ namespace mito::manifolds {
         Manifold(const Manifold &) = delete;
 
         // delete move constructor
-        Manifold(const Manifold &&) = delete;
+        Manifold(Manifold &&) = delete;
 
         // delete assignment operator
-        const Manifold & operator=(const Manifold &) = delete;
+        Manifold & operator=(const Manifold &) = delete;
 
         // delete move assignment operator
-        const Manifold & operator=(const Manifold &&) = delete;
+        Manifold & operator=(Manifold &&) = delete;
 
       public:
         inline auto sanityCheck() -> bool

--- a/lib/mito/materials/Gent.h
+++ b/lib/mito/materials/Gent.h
@@ -11,7 +11,8 @@ namespace mito::materials {
             _rho(rho),
             _kappa(kappa),
             _mu(mu),
-            _Jm(Jm) {};
+            _Jm(Jm)
+        {}
 
         template <int D /*dim*/>
         constexpr auto Constitutive(const vector_t<D> & u, const matrix_t<D> & Du, matrix_t<D> & P)

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -41,10 +41,10 @@ namespace mito::mesh {
         Mesh(const Mesh &) = delete;
 
         // delete assignment operator
-        const Mesh & operator=(const Mesh &) = delete;
+        Mesh & operator=(const Mesh &) = delete;
 
         // delete move assignment operator
-        const Mesh & operator=(const Mesh &&) = delete;
+        Mesh & operator=(Mesh &&) = delete;
 
       private:
         template <int I, int J>
@@ -107,7 +107,6 @@ namespace mito::mesh {
 
         inline auto erase(const cell_t & cell) -> void
         {
-
             // loop on the subcells of {cell}
             for (const auto & subcell : cell->composition()) {
                 // decrement the orientations count for this cell footprint id, depending on the

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -15,7 +15,7 @@ namespace mito::mesh {
         static constexpr int N = cellT::resource_t::order;
         // get the family this cell type belongs to (e.g. simplicial cells)
         template <int I>
-        using cell_family_t = typename cellT::resource_t::cell_family_t<I>;
+        using cell_family_t = typename cellT::resource_t::template cell_family_t<I>;
         // typedef for geometry type
         using geometry_t = geometry::geometry_t<D>;
         // typedef for a collection of cells

--- a/lib/mito/mesh/flipdiagonal.h
+++ b/lib/mito/mesh/flipdiagonal.h
@@ -101,24 +101,27 @@ namespace mito::mesh {
         topology::simplex_composition_t<2> new_simplex_composition_0;
         new_simplex_composition_0[0] = diagonal_segment;
 
+        topology::simplex_t<1> subsimplex_to_erase = *boundary_simplices.begin();
         for (const auto & subsimplex : boundary_simplices) {
             if (headTailConnected(new_simplex_composition_0[0], subsimplex)) {
                 new_simplex_composition_0[1] = subsimplex;
-                boundary_simplices.erase(subsimplex);
-                topology.erase(subsimplex);
+                subsimplex_to_erase = subsimplex;
                 break;
             }
         }
+        boundary_simplices.erase(subsimplex_to_erase);
+        topology.erase(subsimplex_to_erase);
         assert(boundary_simplices.size() == 3);
 
         for (const auto & subsimplex : boundary_simplices) {
             if (headTailConnected(new_simplex_composition_0[1], subsimplex)) {
                 new_simplex_composition_0[2] = subsimplex;
-                boundary_simplices.erase(subsimplex);
-                topology.erase(subsimplex);
+                subsimplex_to_erase = subsimplex;
                 break;
             }
         }
+        boundary_simplices.erase(subsimplex_to_erase);
+        topology.erase(subsimplex_to_erase);
         assert(boundary_simplices.size() == 2);
 
         assert(headTailConnected(new_simplex_composition_0[2], new_simplex_composition_0[0]));
@@ -129,21 +132,23 @@ namespace mito::mesh {
         for (const auto & subsimplex : boundary_simplices) {
             if (headTailConnected(new_simplex_composition_1[0], subsimplex)) {
                 new_simplex_composition_1[1] = subsimplex;
-                boundary_simplices.erase(subsimplex);
-                topology.erase(subsimplex);
+                subsimplex_to_erase = subsimplex;
                 break;
             }
         }
+        boundary_simplices.erase(subsimplex_to_erase);
+        topology.erase(subsimplex_to_erase);
         assert(boundary_simplices.size() == 1);
 
         for (const auto & subsimplex : boundary_simplices) {
             if (headTailConnected(new_simplex_composition_1[1], subsimplex)) {
                 new_simplex_composition_1[2] = subsimplex;
-                boundary_simplices.erase(subsimplex);
-                topology.erase(subsimplex);
+                subsimplex_to_erase = subsimplex;
                 break;
             }
         }
+        boundary_simplices.erase(subsimplex_to_erase);
+        topology.erase(subsimplex_to_erase);
         assert(boundary_simplices.size() == 0);
 
         assert(headTailConnected(new_simplex_composition_1[2], new_simplex_composition_1[0]));

--- a/lib/mito/mesh/flipdiagonal.h
+++ b/lib/mito/mesh/flipdiagonal.h
@@ -6,8 +6,9 @@
 namespace mito::mesh {
 
 
-    const auto & findSharedSimplex(
+    auto findSharedSimplex(
         const topology::simplex_t<2> & simplex0, const topology::simplex_t<2> & simplex1)
+        -> const topology::unoriented_simplex_t<1> &
     {
         // loop on lower-dimensional simplices to find the edge shared by the two simplices
         for (const auto & subsimplex0 : simplex0->composition()) {
@@ -30,9 +31,9 @@ namespace mito::mesh {
     }
 
 
-    topology::vertex_vector_t oppositeVertices(
+    auto oppositeVertices(
         const topology::simplex_t<2> & simplex0, const topology::simplex_t<2> & simplex1,
-        const auto & shared_simplex)
+        const auto & shared_simplex) -> topology::vertex_vector_t
     {
         // need a regular set (not an unordered one) because set_difference works with ordered sets
         using vertex_set_t = std::set<topology::vertex_t>;
@@ -162,8 +163,6 @@ namespace mito::mesh {
         // all done
         return;
     }
-
-
 }
 
 

--- a/lib/mito/topology/OrientedSimplex.h
+++ b/lib/mito/topology/OrientedSimplex.h
@@ -48,13 +48,13 @@ namespace mito::topology {
         OrientedSimplex(const OrientedSimplex &) = delete;
 
         // delete move constructor
-        OrientedSimplex(const OrientedSimplex &&) = delete;
+        OrientedSimplex(OrientedSimplex &&) = delete;
 
         // delete assignment operator
-        const OrientedSimplex & operator=(const OrientedSimplex &) = delete;
+        OrientedSimplex & operator=(const OrientedSimplex &) = delete;
 
         // delete move assignment operator
-        const OrientedSimplex & operator=(const OrientedSimplex &&) = delete;
+        OrientedSimplex & operator=(OrientedSimplex &&) = delete;
 
       public:
         // accessor for the unoriented footprint

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -35,7 +35,14 @@ namespace mito::topology {
             _orientations() {};
 
         // destructor
-        ~OrientedSimplexFactory() {};
+        ~OrientedSimplexFactory()
+        {
+            if (_oriented_simplices.size() > 0) {
+                for (const auto & oriented_simplex : _oriented_simplices) {
+                    oriented_simplex->~OrientedSimplex<D>();
+                }
+            }
+        };
 
       private:
         inline auto existsOrientedSimplex(

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -65,8 +65,8 @@ namespace mito::topology {
 
         // return an oriented simplex riding on footprint {simplex} and with orientation
         // {orientation} (either create a new oriented simplex if such oriented simplex does not
-        // exist in the factory or return the existing representative of the class of equivalence of
-        // oriented simplices with footprint {simplex} orientation {orientation}
+        // exist in the factory or return the existing representative of the class of
+        // equivalence of oriented simplices with footprint {simplex} orientation {orientation}
         inline auto orientedSimplex(const unoriented_simplex_t<D> & simplex, bool orientation)
             -> const simplex_t<D> &
         {
@@ -95,8 +95,8 @@ namespace mito::topology {
         }
 
         // return a simplex with composition {composition} (either create a new simplex if such
-        // simplex does not exist in the factory or return the existing representative of the class
-        // of equivalence of simplices with this composition)
+        // simplex does not exist in the factory or return the existing representative of the
+        // class of equivalence of simplices with this composition)
         inline auto orientedSimplex(const simplex_composition_t<D> & composition)
             -> const simplex_t<D> &
         requires(D > 0)
@@ -109,10 +109,12 @@ namespace mito::topology {
                 assert(false);
             }
 
-            // get the representative of simplices with composition {composition} from the factory
+            // get the representative of simplices with composition {composition} from the
+            // factory
             const auto & simplex = _simplex_factory.simplex(composition);
 
-            // compute the orientation of the current composition with respect to the representative
+            // compute the orientation of the current composition with respect to the
+            // representative
             bool orientation = _orientation(composition, simplex);
 
             // return an oriented simplex riding on {simplex} with {orientation}
@@ -122,7 +124,8 @@ namespace mito::topology {
         inline auto orientedSimplex(bool orientation) -> const simplex_t<0> &
         requires(D == 0)
         {
-            // get the representative of simplices with composition {composition} from the factory
+            // get the representative of simplices with composition {composition} from the
+            // factory
             const auto & simplex = _simplex_factory.simplex();
 
             // return an oriented simplex riding on {simplex} with {orientation}
@@ -137,8 +140,8 @@ namespace mito::topology {
             return _simplex_factory.simplex();
         }
 
-        // erase an oriented simplex from the factory (this method actually erases the simplex only
-        // if there is no one else using it, otherwise does nothing)
+        // erase an oriented simplex from the factory (this method actually erases the simplex
+        // only if there is no one else using it, otherwise does nothing)
         inline auto erase(const simplex_t<D> & oriented_simplex) -> void
         {
             // sanity check
@@ -159,7 +162,8 @@ namespace mito::topology {
             // erase this oriented simplex from the oriented simplex factory
             _orientations.erase(mytuple);
 
-            // if this simplex is the last one using the footprint (other than the copy we just did)
+            // if this simplex is the last one using the footprint (other than the copy we just
+            // did)
             if (footprint.references() == 2) {
                 // cleanup the unoriented factory around {footprint}
                 _simplex_factory.erase(footprint);

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -85,11 +85,9 @@ namespace mito::topology {
             // otherwise
             else {
                 // create a new oriented simplex riding on simplex {simplex} with orientation
-                // {orientation}
-                auto oriented_simplex = _emplace_simplex(simplex, orientation);
-
-                // register it in the map
-                auto it = _orientations.insert(std::make_pair(tuple, oriented_simplex));
+                // {orientation} and register it in the map
+                auto it = _orientations.insert(
+                    std::make_pair(tuple, _emplace_simplex(simplex, orientation)));
 
                 // and return it
                 return it.first->second;

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -129,6 +129,14 @@ namespace mito::topology {
             return orientedSimplex(simplex, orientation);
         }
 
+        // instantiate a vertex
+        inline auto vertex() -> const vertex_t &
+        requires(D == 0)
+        {
+            // ask the factory of unoriented vertices for an unoriented vertex
+            return _simplex_factory.simplex();
+        }
+
         // erase an oriented simplex from the factory (this method actually erases the simplex only
         // if there is no one else using it, otherwise does nothing)
         inline auto erase(const simplex_t<D> & oriented_simplex) -> void

--- a/lib/mito/topology/Simplex.h
+++ b/lib/mito/topology/Simplex.h
@@ -34,13 +34,13 @@ namespace mito::topology {
         Simplex(const Simplex &) = delete;
 
         // delete move constructor
-        Simplex(const Simplex &&) = delete;
+        Simplex(Simplex &&) = delete;
 
         // delete assignment operator
-        const Simplex & operator=(const Simplex &) = delete;
+        Simplex & operator=(const Simplex &) = delete;
 
         // delete move assignment operator
-        const Simplex & operator=(const Simplex &&) = delete;
+        Simplex & operator=(Simplex &&) = delete;
 
       public:
         // accessor for the subsimplices
@@ -139,13 +139,13 @@ namespace mito::topology {
         Simplex(const Simplex &) = delete;
 
         // delete move constructor
-        Simplex(const Simplex &&) = delete;
+        Simplex(Simplex &&) = delete;
 
         // delete assignment operator
-        const Simplex & operator=(const Simplex &) = delete;
+        Simplex & operator=(const Simplex &) = delete;
 
         // delete move assignment operator
-        const Simplex & operator=(const Simplex &&) = delete;
+        Simplex & operator=(Simplex &&) = delete;
 
       public:
         // returns the simplex id

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -199,7 +199,6 @@ namespace mito::topology {
         // is no one else using it, otherwise does nothing)
         inline auto erase(const unoriented_simplex_t<0> & simplex) -> void
         {
-
             // sanity check
             assert(simplex.references() > 0);
 

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -71,11 +71,9 @@ namespace mito::topology {
             }
             // otherwise
             else {
-                // emplace simplex in {_simplices}
-                auto simplex = _emplace_simplex(composition);
-
-                // register it in the compositions map
-                auto it = _compositions.insert(std::make_pair(representative, simplex));
+                // emplace simplex in {_simplices} and register it in the compositions map
+                auto it = _compositions.insert(
+                    std::make_pair(representative, _emplace_simplex(composition)));
 
                 // and return it
                 return it.first->second;

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -43,7 +43,14 @@ namespace mito::topology {
         SimplexFactory() : _simplices(100 /*segment size */), _compositions() {};
 
         // destructor
-        ~SimplexFactory() {};
+        ~SimplexFactory()
+        {
+            if (_simplices.size() > 0) {
+                for (const auto & simplex : _simplices) {
+                    simplex->~Simplex<D>();
+                }
+            }
+        }
 
         // return a simplex with composition {composition} (either create a new simplex if such
         // simplex does not exist in the factory or return the existing representative of the class
@@ -184,7 +191,14 @@ namespace mito::topology {
         SimplexFactory() : _simplices(100 /*segment size */) {};
 
         // destructor
-        ~SimplexFactory() {};
+        ~SimplexFactory()
+        {
+            if (_simplices.size() > 0) {
+                for (const auto & simplex : _simplices) {
+                    simplex->~Simplex<0>();
+                }
+            }
+        }
 
         // return a simplex with composition {composition} (either create a new simplex if such
         // simplex does not exist in the factory or return the existing representative of the class

--- a/lib/mito/topology/Topology.h
+++ b/lib/mito/topology/Topology.h
@@ -56,11 +56,7 @@ namespace mito::topology {
         }
 
         // instantiate a vertex
-        inline auto vertex() -> const vertex_t &
-        {
-            // ask the factory of oriented simplices
-            return simplex<0>(true)->footprint();
-        }
+        inline auto vertex() -> const vertex_t &;
 
         // instantiate a segment
         inline auto segment(const simplex_composition_t<1> & simplices) -> const simplex_t<1> &
@@ -270,6 +266,14 @@ inline auto
 mito::topology::Topology::_get_factory<3>() const -> const oriented_simplex_factory_t<3> &
 {
     return _tetrahedron_factory;
+}
+
+// instantiate a vertex
+inline auto
+mito::topology::Topology::vertex() -> const vertex_t &
+{
+    // ask the factory of vertices for an unoriented vertex
+    return _get_factory<0>().vertex();
 }
 
 #endif    // mito_topology_Topology_h

--- a/lib/mito/topology/Topology.h
+++ b/lib/mito/topology/Topology.h
@@ -12,11 +12,7 @@ namespace mito::topology {
     class Topology {
       private:
         // default constructor
-        Topology() :
-            _vertex_factory(),
-            _segment_factory(),
-            _triangle_factory(),
-            _tetrahedron_factory() {};
+        Topology();
 
         // delete copy constructor
         Topology(const Topology &) = delete;
@@ -25,150 +21,68 @@ namespace mito::topology {
         void operator=(const Topology &) = delete;
 
         // destructor
-        ~Topology() {};
+        ~Topology();
 
       public:
         template <int D>
         inline auto simplex(const unoriented_simplex_t<D> & footprint, bool orientation)
-            -> const simplex_t<D> &
-        {
-            // ask the factory of oriented simplices
-            return _get_factory<D>().orientedSimplex(footprint, orientation);
-        }
+            -> const simplex_t<D> &;
 
         // return a simplex with composition {composition} (either create a new simplex if such
         // simplex does not exist in the factory or return the existing representative of the class
         // of equivalence of simplices with this composition)
         template <int D>
         inline auto simplex(const simplex_composition_t<D> & composition) -> const simplex_t<D> &
-        requires(D > 0)
-        {
-            // ask the factory of oriented simplices
-            return _get_factory<D>().orientedSimplex(composition);
-        }
+        requires(D > 0);
 
         template <int D>
         inline auto simplex(bool orientation) -> const simplex_t<0> &
-        requires(D == 0)
-        {
-            // ask the factory of oriented simplices
-            return _get_factory<0>().orientedSimplex(orientation);
-        }
+        requires(D == 0);
 
         // instantiate a vertex
         inline auto vertex() -> const vertex_t &;
 
         // instantiate a segment
-        inline auto segment(const simplex_composition_t<1> & simplices) -> const simplex_t<1> &
-        {
-            return simplex<1>(simplices);
-        }
+        inline auto segment(const simplex_composition_t<1> & simplices) -> const simplex_t<1> &;
 
         // instantiate a triangle
-        inline auto triangle(const simplex_composition_t<2> & simplices) -> const simplex_t<2> &
-        {
-            return simplex<2>(simplices);
-        }
+        inline auto triangle(const simplex_composition_t<2> & simplices) -> const simplex_t<2> &;
 
         // instantiate a tetrahedron
-        inline auto tetrahedron(const simplex_composition_t<3> & simplices) -> const simplex_t<3> &
-        {
-            return simplex<3>(simplices);
-        }
+        inline auto tetrahedron(const simplex_composition_t<3> & simplices) -> const simplex_t<3> &;
 
         // instantiate a segment from unoriented vertices
         inline auto segment(const vertex_simplex_composition_t<1> & simplices)
-            -> const simplex_t<1> &
-        {
-            return segment({ simplex(simplices[0], false), simplex(simplices[1], true) });
-        }
+            -> const simplex_t<1> &;
 
         // instantiate a triangle
         inline auto triangle(const vertex_simplex_composition_t<2> & vertices)
-            -> const simplex_t<2> &
-        {
-            return simplex<2>({ segment({ vertices[0], vertices[1] }),
-                                segment({ vertices[1], vertices[2] }),
-                                segment({ vertices[2], vertices[0] }) });
-        }
+            -> const simplex_t<2> &;
 
         // instantiate a tetrahedron
         inline auto tetrahedron(const vertex_simplex_composition_t<3> & vertices)
-            -> const simplex_t<3> &
-        {
-            return simplex<3>({ triangle({ vertices[0], vertices[1], vertices[3] }),
-                                triangle({ vertices[1], vertices[2], vertices[3] }),
-                                triangle({ vertices[2], vertices[0], vertices[3] }),
-                                triangle({ vertices[0], vertices[2], vertices[1] }) });
-        }
+            -> const simplex_t<3> &;
 
         // returns whether the oriented simplex exists in the factory
         template <int D>
-        inline auto exists(const simplex_t<D> & simplex) const -> bool
-        {
-            return _get_factory<D>().existsOrientedSimplex(
-                simplex->footprint(), simplex->orientation());
-        }
+        inline auto exists(const simplex_t<D> & simplex) const -> bool;
 
         // returns whether there exists the flipped oriented simplex in the factory
         template <int D>
-        inline auto exists_flipped(const simplex_t<D> & simplex) const -> bool
-        {
-            return _get_factory<D>().existsOrientedSimplex(
-                simplex->footprint(), !simplex->orientation());
-        }
+        inline auto exists_flipped(const simplex_t<D> & simplex) const -> bool;
 
         // returns the simplex with opposite orientation
         template <int D>
-        inline auto flip(const simplex_t<D> & simplex) -> const simplex_t<D> &
-        {
-            // ask the factory of oriented simplices
-            return _get_factory<D>().orientedSimplex(simplex->footprint(), !simplex->orientation());
-        }
+        inline auto flip(const simplex_t<D> & simplex) -> const simplex_t<D> &;
 
       private:
         template <int D>
         inline auto _erase(const simplex_t<D> & simplex) -> void
-        requires(D == 0)
-        {
-            // erase the vertex from the factory
-            _get_factory<D>().erase(simplex);
-
-            // all done
-            return;
-        }
+        requires(D == 0);
 
         template <int D>
         inline auto _erase(const simplex_t<D> & simplex) -> void
-        requires(D > 0)
-        {
-            // QUESTION: method {reset} is not {const} unless the {_handle} of the shared pointer is
-            //          declared mutable. Should we call reset here and make the handle mutable or
-            //          should we accept that {element} points to an invalid resource after call to
-            //          {erase}?
-
-            // sanity check
-            assert(simplex.references() > 0);
-
-            // grab a copy of the composition
-            auto composition = simplex->composition();
-
-            // cleanup the oriented factory around {simplex}
-            _get_factory<D>().erase(simplex);
-
-            // loop on subsimplices
-            for (const auto & subsimplex : composition) {
-                // if this simplex is the last one using the subsimplex (other than the copy we just
-                // did)
-                if (subsimplex.references() == 2) {
-                    // recursively erase the subsimplices
-                    _erase(subsimplex);
-                }
-            }
-
-            // all done
-            return;
-        }
+        requires(D > 0);
 
         // mutator for the simplex factory of dimension D
         template <int D>
@@ -180,17 +94,7 @@ namespace mito::topology {
 
       public:
         template <int D>
-        inline auto erase(const simplex_t<D> & simplex) -> void
-        {
-            // if someone else (other than the topology) is still using this resource
-            if (simplex.references() > 1) {
-                // do nothing
-                return;
-            }
-
-            // otherwise, erase the simplex
-            return _erase(simplex);
-        }
+        inline auto erase(const simplex_t<D> & simplex) -> void;
 
       private:
         // factory for vertices
@@ -211,71 +115,11 @@ namespace mito::topology {
     };
 }
 
-// TOFIX: split header into {Topology.h} and {Topology.icc} so these can be moved to the icc file
-template <>
-inline auto
-mito::topology::Topology::_get_factory<0>() -> oriented_simplex_factory_t<0> &
-{
-    return _vertex_factory;
-}
 
-template <>
-inline auto
-mito::topology::Topology::_get_factory<1>() -> oriented_simplex_factory_t<1> &
-{
-    return _segment_factory;
-}
-
-template <>
-inline auto
-mito::topology::Topology::_get_factory<2>() -> oriented_simplex_factory_t<2> &
-{
-    return _triangle_factory;
-}
-
-template <>
-inline auto
-mito::topology::Topology::_get_factory<3>() -> oriented_simplex_factory_t<3> &
-{
-    return _tetrahedron_factory;
-}
-
-template <>
-inline auto
-mito::topology::Topology::_get_factory<0>() const -> const oriented_simplex_factory_t<0> &
-{
-    return _vertex_factory;
-}
-
-template <>
-inline auto
-mito::topology::Topology::_get_factory<1>() const -> const oriented_simplex_factory_t<1> &
-{
-    return _segment_factory;
-}
-
-template <>
-inline auto
-mito::topology::Topology::_get_factory<2>() const -> const oriented_simplex_factory_t<2> &
-{
-    return _triangle_factory;
-}
-
-template <>
-inline auto
-mito::topology::Topology::_get_factory<3>() const -> const oriented_simplex_factory_t<3> &
-{
-    return _tetrahedron_factory;
-}
-
-// instantiate a vertex
-inline auto
-mito::topology::Topology::vertex() -> const vertex_t &
-{
-    // ask the factory of vertices for an unoriented vertex
-    return _get_factory<0>().vertex();
-}
+// get the inline definitions
+#define mito_topology_Topology_icc
+#include "Topology.icc"
+#undef mito_topology_Topology_icc
 
 #endif    // mito_topology_Topology_h
-
 // end of file

--- a/lib/mito/topology/Topology.h
+++ b/lib/mito/topology/Topology.h
@@ -158,7 +158,7 @@ namespace mito::topology {
             std::get<D>(_factories).erase(simplex);
 
             // loop on subsimplices
-            for (auto & subsimplex : composition) {
+            for (const auto & subsimplex : composition) {
                 // if this simplex is the last one using the subsimplex (other than the copy we just
                 // did)
                 if (subsimplex.references() == 2) {

--- a/lib/mito/topology/Topology.icc
+++ b/lib/mito/topology/Topology.icc
@@ -1,0 +1,236 @@
+// -*- C++ -*-
+//
+
+#if !defined(mito_topology_Topology_icc)
+#error This header file contains implementation details of class mito::topology::Topology
+#else
+
+mito::topology::Topology::Topology() :
+    _vertex_factory(),
+    _segment_factory(),
+    _triangle_factory(),
+    _tetrahedron_factory() {};
+
+mito::topology::Topology::~Topology() {};
+
+template <int D>
+inline auto
+mito::topology::Topology::simplex(const unoriented_simplex_t<D> & footprint, bool orientation)
+    -> const simplex_t<D> &
+{
+    // ask the factory of oriented simplices
+    return _get_factory<D>().orientedSimplex(footprint, orientation);
+}
+
+template <int D>
+inline auto
+mito::topology::Topology::simplex(const simplex_composition_t<D> & composition)
+    -> const simplex_t<D> &
+requires(D > 0)
+{
+    // ask the factory of oriented simplices
+    return _get_factory<D>().orientedSimplex(composition);
+}
+
+template <int D>
+inline auto
+mito::topology::Topology::simplex(bool orientation) -> const simplex_t<0> &
+requires(D == 0)
+{
+    // ask the factory of oriented simplices
+    return _get_factory<0>().orientedSimplex(orientation);
+}
+
+inline auto
+mito::topology::Topology::segment(const simplex_composition_t<1> & simplices)
+    -> const simplex_t<1> &
+{
+    return simplex<1>(simplices);
+}
+
+inline auto
+mito::topology::Topology::triangle(const simplex_composition_t<2> & simplices)
+    -> const simplex_t<2> &
+{
+    return simplex<2>(simplices);
+}
+
+inline auto
+mito::topology::Topology::tetrahedron(const simplex_composition_t<3> & simplices)
+    -> const simplex_t<3> &
+{
+    return simplex<3>(simplices);
+}
+
+inline auto
+mito::topology::Topology::segment(const vertex_simplex_composition_t<1> & simplices)
+    -> const simplex_t<1> &
+{
+    return segment({ simplex(simplices[0], false), simplex(simplices[1], true) });
+}
+
+inline auto
+mito::topology::Topology::triangle(const vertex_simplex_composition_t<2> & vertices)
+    -> const simplex_t<2> &
+{
+    return simplex<2>({ segment({ vertices[0], vertices[1] }),
+                        segment({ vertices[1], vertices[2] }),
+                        segment({ vertices[2], vertices[0] }) });
+}
+
+inline auto
+mito::topology::Topology::tetrahedron(const vertex_simplex_composition_t<3> & vertices)
+    -> const simplex_t<3> &
+{
+    return simplex<3>({ triangle({ vertices[0], vertices[1], vertices[3] }),
+                        triangle({ vertices[1], vertices[2], vertices[3] }),
+                        triangle({ vertices[2], vertices[0], vertices[3] }),
+                        triangle({ vertices[0], vertices[2], vertices[1] }) });
+}
+
+template <int D>
+inline auto
+mito::topology::Topology::exists(const simplex_t<D> & simplex) const -> bool
+{
+    return _get_factory<D>().existsOrientedSimplex(simplex->footprint(), simplex->orientation());
+}
+
+template <int D>
+inline auto
+mito::topology::Topology::exists_flipped(const simplex_t<D> & simplex) const -> bool
+{
+    return _get_factory<D>().existsOrientedSimplex(simplex->footprint(), !simplex->orientation());
+}
+
+template <int D>
+inline auto
+mito::topology::Topology::flip(const simplex_t<D> & simplex) -> const simplex_t<D> &
+{
+    // ask the factory of oriented simplices
+    return _get_factory<D>().orientedSimplex(simplex->footprint(), !simplex->orientation());
+}
+
+template <int D>
+inline auto
+mito::topology::Topology::_erase(const simplex_t<D> & simplex) -> void
+requires(D == 0)
+{
+    // erase the vertex from the factory
+    _get_factory<D>().erase(simplex);
+
+    // all done
+    return;
+}
+
+template <int D>
+inline auto
+mito::topology::Topology::_erase(const simplex_t<D> & simplex) -> void
+requires(D > 0)
+{
+    // QUESTION: method {reset} is not {const} unless the {_handle} of the shared pointer is
+    //          declared mutable. Should we call reset here and make the handle mutable or
+    //          should we accept that {element} points to an invalid resource after call to
+    //          {erase}?
+
+    // sanity check
+    assert(simplex.references() > 0);
+
+    // grab a copy of the composition
+    auto composition = simplex->composition();
+
+    // cleanup the oriented factory around {simplex}
+    _get_factory<D>().erase(simplex);
+
+    // loop on subsimplices
+    for (const auto & subsimplex : composition) {
+        // if this simplex is the last one using the subsimplex (other than the copy we just
+        // did)
+        if (subsimplex.references() == 2) {
+            // recursively erase the subsimplices
+            _erase(subsimplex);
+        }
+    }
+
+    // all done
+    return;
+}
+
+template <int D>
+inline auto
+mito::topology::Topology::erase(const simplex_t<D> & simplex) -> void
+{
+    // if someone else (other than the topology) is still using this resource
+    if (simplex.references() > 1) {
+        // do nothing
+        return;
+    }
+
+    // otherwise, erase the simplex
+    return _erase(simplex);
+}
+
+template <>
+inline auto
+mito::topology::Topology::_get_factory<0>() -> oriented_simplex_factory_t<0> &
+{
+    return _vertex_factory;
+}
+
+template <>
+inline auto
+mito::topology::Topology::_get_factory<1>() -> oriented_simplex_factory_t<1> &
+{
+    return _segment_factory;
+}
+
+template <>
+inline auto
+mito::topology::Topology::_get_factory<2>() -> oriented_simplex_factory_t<2> &
+{
+    return _triangle_factory;
+}
+
+template <>
+inline auto
+mito::topology::Topology::_get_factory<3>() -> oriented_simplex_factory_t<3> &
+{
+    return _tetrahedron_factory;
+}
+
+template <>
+inline auto
+mito::topology::Topology::_get_factory<0>() const -> const oriented_simplex_factory_t<0> &
+{
+    return _vertex_factory;
+}
+
+template <>
+inline auto
+mito::topology::Topology::_get_factory<1>() const -> const oriented_simplex_factory_t<1> &
+{
+    return _segment_factory;
+}
+
+template <>
+inline auto
+mito::topology::Topology::_get_factory<2>() const -> const oriented_simplex_factory_t<2> &
+{
+    return _triangle_factory;
+}
+
+template <>
+inline auto
+mito::topology::Topology::_get_factory<3>() const -> const oriented_simplex_factory_t<3> &
+{
+    return _tetrahedron_factory;
+}
+
+inline auto
+mito::topology::Topology::vertex() -> const vertex_t &
+{
+    // ask the factory of vertices for an unoriented vertex
+    return _get_factory<0>().vertex();
+}
+
+#endif    // mito_topology_Topology_icc
+// end of file

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -293,6 +293,18 @@ namespace mito::utilities {
         }
 
       private:
+        // delete copy constructor
+        SegmentedContainer(const SegmentedContainer &) = delete;
+
+        // delete move constructor
+        SegmentedContainer(SegmentedContainer &&) = delete;
+
+        // delete assignment operator
+        SegmentedContainer & operator=(const SegmentedContainer &) = delete;
+
+        // delete move assignment operator
+        SegmentedContainer & operator=(SegmentedContainer &&) = delete;
+
         // the segment size
         const int _segment_size;
         // the beginning of the container

--- a/lib/mito/utilities/SharedPointer.icc
+++ b/lib/mito/utilities/SharedPointer.icc
@@ -159,7 +159,7 @@ template <class Resource>
 auto
 mito::utilities::SharedPointer<Resource>::_acquire() const -> void
 {
-    // acquire resource
+    // acquire resource (increment reference count)
     _handle->_acquire();
     // all done
     return;
@@ -171,10 +171,12 @@ mito::utilities::SharedPointer<Resource>::_release() const -> void
 {
     // if the handle is in valid state
     if (_handle != nullptr) {
-        // release my current handle
+        // release my current handle (decreases reference count by one)
+        const auto reference_count = _handle->_release();
         // if the resource is now unused
-        if (_handle->_release() == 0 && _container != nullptr) {
-            // erase it from the container
+        if (reference_count == 0 && _container != nullptr) {
+            // erase it from the container (decrement the number of elements and add the address of
+            // the element to the queue of the available locations for reuse)
             return _container->erase(*this);
         }
 

--- a/tests/mito.lib/flip-diagonal/main.cc
+++ b/tests/mito.lib/flip-diagonal/main.cc
@@ -44,8 +44,10 @@ TEST(FlipDiagonal, TestFlipDiagonal)
     EXPECT_EQ(mesh.nCells(), 2);
 
     // assert that the original diagonal was erased
-    EXPECT_EQ(segment_e.references(), 0);
-    EXPECT_EQ(segment_e_flip.references(), 0);
+    // TOFIX: accessing to a deleted ref cause undefined behavior.
+    // re-enable when methods {exist} and {find} are in place
+    // EXPECT_EQ(segment_e.references(), 0);
+    // EXPECT_EQ(segment_e_flip.references(), 0);
 
     // assert that the new diagonal is now in use (by the factory and by the two triangles)
     auto & segment_f = topology.segment({ vertex1, vertex3 });


### PR DESCRIPTION
Destructors of {Shareable}s were never called since items were constructed by means of a placement new by {SegmentedContainer}, causing memory leaks and undefined behavior. Since the factory instantiate {Shareable} at the memory position supplied by {SegmentedContainer} they also explicitly now call the destructors of the {Shareable} objects.
