### PR TITLE
Mark handle of {SharedPointer}s as private

### DIFF
--- a/lib/mito/geometry/PointCloud.h
+++ b/lib/mito/geometry/PointCloud.h
@@ -36,7 +36,7 @@ namespace mito::geometry {
             // iterate on points
             std::cout << "Point cloud:" << std::endl;
             for (const auto & pPointMap : _compositions) {
-                std::cout << *pPointMap.second.handle() << std::endl;
+                std::cout << pPointMap.second->coordinates() << std::endl;
             }
             // all done
             return;

--- a/lib/mito/io/vtk/writer.h
+++ b/lib/mito/io/vtk/writer.h
@@ -30,7 +30,7 @@ namespace mito::io::vtk {
         -> void
     {
         // retrieve the coordinates of the point
-        const auto & coordinates = pPoint.handle()->coordinates();
+        const auto & coordinates = pPoint->coordinates();
         // add the point as new vtk point
         pointsVtk->InsertNextPoint(coordinates[0], coordinates[1], coordinates[2]);
     }
@@ -40,7 +40,7 @@ namespace mito::io::vtk {
         -> void
     {
         // retrieve the coordinates of the point
-        const auto & coordinates = pPoint.handle()->coordinates();
+        const auto & coordinates = pPoint->coordinates();
         // add the point as new vtk point
         pointsVtk->InsertNextPoint(coordinates[0], coordinates[1], 0.);
     }

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -23,7 +23,7 @@ namespace mito::mesh {
         // this map maps a simplex id to a tuple of two integers counting how many times a simplex
         // appears with - or + orientation
         using orientation_map_t =
-            std::unordered_map<topology::unoriented_simplex_id_t, std::array<int, 2>>;
+            std::unordered_map<topology::unoriented_simplex_id_t<D>, std::array<int, 2>>;
 
       public:
         // default constructor

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -111,12 +111,12 @@ namespace mito::mesh {
             for (const auto & subcell : cell->composition()) {
                 // decrement the orientations count for this cell footprint id, depending on the
                 // orientation
-                (subcell->orientation() ? _orientations[subcell->footprint()->id()][0] -= 1 :
-                                          _orientations[subcell->footprint()->id()][1] -= 1);
+                (subcell->orientation() ? _orientations[subcell->footprint().id()][0] -= 1 :
+                                          _orientations[subcell->footprint().id()][1] -= 1);
 
                 // cleanup orientation map
-                if (_orientations[subcell->footprint()->id()] == std::array<int, 2> { 0, 0 }) {
-                    _orientations.erase(subcell->footprint()->id());
+                if (_orientations[subcell->footprint().id()] == std::array<int, 2> { 0, 0 }) {
+                    _orientations.erase(subcell->footprint().id());
                 }
             }
 
@@ -131,8 +131,8 @@ namespace mito::mesh {
         {
             // count how many times this oriented cell occurs in the mesh with opposite orientation
             int count = 0;
-            (!cell->orientation() ? count = _orientations[cell->footprint()->id()][0] :
-                                    count = _orientations[cell->footprint()->id()][1]);
+            (!cell->orientation() ? count = _orientations[cell->footprint().id()][0] :
+                                    count = _orientations[cell->footprint().id()][1]);
 
             // the cell is on the boundary if it never occurs in the mesh with opposite
             // orientation
@@ -179,8 +179,8 @@ namespace mito::mesh {
             for (const auto & subcell : cell->composition()) {
                 // increment the orientations count for this cell footprint id, depending on the
                 // orientation
-                (subcell->orientation() ? _orientations[subcell->footprint()->id()][0] += 1 :
-                                          _orientations[subcell->footprint()->id()][1] += 1);
+                (subcell->orientation() ? _orientations[subcell->footprint().id()][0] += 1 :
+                                          _orientations[subcell->footprint().id()][1] += 1);
             }
 
             // all done

--- a/lib/mito/mesh/flipdiagonal.h
+++ b/lib/mito/mesh/flipdiagonal.h
@@ -68,7 +68,7 @@ namespace mito::mesh {
         const auto & shared_simplex = findSharedSimplex(simplex0, simplex1);
 
         // assert you could find it
-        assert(shared_simplex.handle() != nullptr);
+        assert(!shared_simplex.is_nullptr());
 
         // show me
         // std::cout << "shared simplex: " << *shared_simplex << std::endl;

--- a/lib/mito/mesh/flipdiagonal.h
+++ b/lib/mito/mesh/flipdiagonal.h
@@ -14,7 +14,7 @@ namespace mito::mesh {
         for (const auto & subsimplex0 : simplex0->composition()) {
             for (const auto & subsimplex1 : simplex1->composition()) {
                 // if you found it
-                if (subsimplex0->footprint_id() == subsimplex1->footprint_id()) {
+                if (subsimplex0->footprint().id() == subsimplex1->footprint().id()) {
                     // report
                     std::cout << "Found it!" << std::endl;
                     // return
@@ -84,7 +84,7 @@ namespace mito::mesh {
         // get boundary simplices of simplex0 (all except diagonal)
         for (const auto & subsimplex : simplex0->composition()) {
             // if it is not the shared simplex
-            if (subsimplex->footprint_id() != shared_simplex->id()) {
+            if (subsimplex->footprint().id() != shared_simplex.id()) {
                 boundary_simplices.insert(subsimplex);
             }
         }
@@ -92,7 +92,7 @@ namespace mito::mesh {
         // get boundary simplices of simplex1 (all except diagonal)
         for (const auto & subsimplex : simplex1->composition()) {
             // if it is not the shared simplex
-            if (subsimplex->footprint_id() != shared_simplex->id()) {
+            if (subsimplex->footprint().id() != shared_simplex.id()) {
                 boundary_simplices.insert(subsimplex);
             }
         }

--- a/lib/mito/topology/OrientedSimplex.h
+++ b/lib/mito/topology/OrientedSimplex.h
@@ -71,19 +71,6 @@ namespace mito::topology {
             return _footprint->composition();
         }
 
-        // returns the id of this (oriented) simplex
-        inline auto id() const -> oriented_simplex_id_t<D>
-        {
-            // the id is the (immutable) address of this object
-            return reinterpret_cast<unoriented_simplex_id_t>(this);
-        }
-
-        // returns the id of this (oriented) simplex
-        inline auto simplex_id() const -> oriented_simplex_id_t<D> { return id(); }
-
-        // returns the (unoriented) footprint id
-        // (the footprint id is the (immutable) address of the unoriented footprint)
-        inline auto footprint_id() const -> unoriented_simplex_id_t<D> { return _footprint->id(); }
 
         // returns the set of vertices
         template <class VERTEX_COLLECTION_T>

--- a/lib/mito/topology/OrientedSimplex.h
+++ b/lib/mito/topology/OrientedSimplex.h
@@ -72,18 +72,18 @@ namespace mito::topology {
         }
 
         // returns the id of this (oriented) simplex
-        inline auto id() const -> oriented_simplex_id_t
+        inline auto id() const -> oriented_simplex_id_t<D>
         {
             // the id is the (immutable) address of this object
             return reinterpret_cast<unoriented_simplex_id_t>(this);
         }
 
         // returns the id of this (oriented) simplex
-        inline auto simplex_id() const -> oriented_simplex_id_t { return id(); }
+        inline auto simplex_id() const -> oriented_simplex_id_t<D> { return id(); }
 
         // returns the (unoriented) footprint id
         // (the footprint id is the (immutable) address of the unoriented footprint)
-        inline auto footprint_id() const -> unoriented_simplex_id_t { return _footprint->id(); }
+        inline auto footprint_id() const -> unoriented_simplex_id_t<D> { return _footprint->id(); }
 
         // returns the set of vertices
         template <class VERTEX_COLLECTION_T>

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -25,7 +25,8 @@ namespace mito::topology {
 
         // typedef for an orientation map of simplices:
         // this map maps a simplex pointer and a boolean to an oriented simplex pointer
-        using orientation_map_t = std::map<std::tuple<unoriented_simplex_id_t, bool>, simplex_t<D>>;
+        using orientation_map_t =
+            std::map<std::tuple<unoriented_simplex_id_t<D>, bool>, simplex_t<D>>;
 
       public:    // TOFIX: should be private but the default constructor of tuple needs it public
         // default constructor
@@ -151,7 +152,7 @@ namespace mito::topology {
             auto footprint = oriented_simplex->footprint();
 
             // get footprint of the oriented simplex
-            unoriented_simplex_id_t id = oriented_simplex->footprint_id();
+            unoriented_simplex_id_t<D> id = oriented_simplex->footprint_id();
 
             // get the key to this oriented simplex
             auto mytuple = std::make_tuple(id, oriented_simplex->orientation());
@@ -221,7 +222,7 @@ namespace mito::topology {
         inline auto _rotate(const simplex_composition_t<2> & composition)
         {
             // an array of oriented simplices ids
-            using oriented_simplex_array_t = std::array<oriented_simplex_id_t, 3>;
+            using oriented_simplex_array_t = std::array<oriented_simplex_id_t<2>, 3>;
 
             // get the oriented simplices from the shared pointers
             auto composition_copy =

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -50,7 +50,7 @@ namespace mito::topology {
             const unoriented_simplex_t<D> & simplex, bool orientation) const -> bool
         {
             // bind the footprint and the orientation in a tuple
-            auto tuple = std::make_tuple(simplex->id(), orientation);
+            auto tuple = std::make_tuple(simplex.id(), orientation);
 
             // look up the tuple in the orientation map
             auto it_find = _orientations.find(tuple);
@@ -72,7 +72,7 @@ namespace mito::topology {
             -> const simplex_t<D> &
         {
             // bind the footprint and the orientation in a tuple
-            auto tuple = std::make_tuple(simplex->id(), orientation);
+            auto tuple = std::make_tuple(simplex.id(), orientation);
 
             // look up the tuple in the orientation map
             auto it_find = _orientations.find(tuple);
@@ -152,7 +152,7 @@ namespace mito::topology {
             auto footprint = oriented_simplex->footprint();
 
             // get footprint of the oriented simplex
-            unoriented_simplex_id_t<D> id = oriented_simplex->footprint_id();
+            unoriented_simplex_id_t<D> id = oriented_simplex->footprint().id();
 
             // get the key to this oriented simplex
             auto mytuple = std::make_tuple(id, oriented_simplex->orientation());
@@ -226,8 +226,8 @@ namespace mito::topology {
 
             // get the oriented simplices from the shared pointers
             auto composition_copy =
-                oriented_simplex_array_t { composition[0]->id(), composition[1]->id(),
-                                           composition[2]->id() };
+                oriented_simplex_array_t { composition[0].id(), composition[1].id(),
+                                           composition[2].id() };
             auto first_simplex = std::min_element(composition_copy.begin(), composition_copy.end());
             std::rotate(composition_copy.begin(), first_simplex, composition_copy.end());
 

--- a/lib/mito/topology/Simplex.h
+++ b/lib/mito/topology/Simplex.h
@@ -47,10 +47,10 @@ namespace mito::topology {
         inline auto composition() const -> const simplex_composition_t<D> & { return _simplices; }
 
         // returns the simplex id
-        inline auto id() const -> unoriented_simplex_id_t
+        inline auto id() const -> unoriented_simplex_id_t<D>
         {
             // the id is the (immutable) address of this object
-            return reinterpret_cast<unoriented_simplex_id_t>(this);
+            return reinterpret_cast<unoriented_simplex_id_t<D>>(this);
         }
 
         // add the vertices of this simplex to a collection of vertices
@@ -149,10 +149,10 @@ namespace mito::topology {
 
       public:
         // returns the simplex id
-        inline auto id() const -> unoriented_simplex_id_t
+        inline auto id() const -> unoriented_simplex_id_t<D>
         {
             // the id is the (immutable) address of this object
-            return reinterpret_cast<unoriented_simplex_id_t>(this);
+            return reinterpret_cast<unoriented_simplex_id_t<D>>(this);
         }
 
         // perform a sanity check

--- a/lib/mito/topology/Simplex.h
+++ b/lib/mito/topology/Simplex.h
@@ -46,13 +46,6 @@ namespace mito::topology {
         // accessor for the subsimplices
         inline auto composition() const -> const simplex_composition_t<D> & { return _simplices; }
 
-        // returns the simplex id
-        inline auto id() const -> unoriented_simplex_id_t<D>
-        {
-            // the id is the (immutable) address of this object
-            return reinterpret_cast<unoriented_simplex_id_t<D>>(this);
-        }
-
         // add the vertices of this simplex to a collection of vertices
         template <class VERTEX_COLLECTION_T>
         void vertices(VERTEX_COLLECTION_T & vertices) const
@@ -148,13 +141,6 @@ namespace mito::topology {
         Simplex & operator=(Simplex &&) = delete;
 
       public:
-        // returns the simplex id
-        inline auto id() const -> unoriented_simplex_id_t<D>
-        {
-            // the id is the (immutable) address of this object
-            return reinterpret_cast<unoriented_simplex_id_t<D>>(this);
-        }
-
         // perform a sanity check
         inline auto sanityCheck() const -> bool
         {

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -30,12 +30,12 @@ namespace mito::topology {
         //      2 pointers to nodes into a pointer to edge,
         //      3 pointers to edges into a pointer to face, ...
         // edges composition
-        // std::map<std::array<unoriented_simplex_id_t, 2>, unoriented_simplex_t<1>>
+        // std::map<std::array<unoriented_simplex_id_t<D>, 2>, unoriented_simplex_t<1>>
         // faces compositions
-        // std::map<std::array<unoriented_simplex_id_t, 3>, unoriented_simplex_t<2>>
+        // std::map<std::array<unoriented_simplex_id_t<D>, 3>, unoriented_simplex_t<2>>
         // volumes compositions
-        // std::map<std::array<unoriented_simplex_id_t, 4>, unoriented_simplex_t<3>>
-        using composition_t = std::array<unoriented_simplex_id_t, D + 1>;
+        // std::map<std::array<unoriented_simplex_id_t<D>, 4>, unoriented_simplex_t<3>>
+        using composition_t = std::array<unoriented_simplex_id_t<D>, D + 1>;
         using composition_map_t = std::map<composition_t, unoriented_simplex_t<D>>;
 
       private:

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -134,8 +134,8 @@ namespace mito::topology {
         -> composition_t
     {
         // initialize representative with footprints of simplices in current composition
-        composition_t representative { composition[0]->footprint_id(),
-                                       composition[1]->footprint_id() };
+        composition_t representative { composition[0]->footprint().id(),
+                                       composition[1]->footprint().id() };
         // pick a representative (factor out equivalence relation)
         std::sort(representative.begin(), representative.end());
         // all done
@@ -148,9 +148,9 @@ namespace mito::topology {
         -> composition_t
     {
         // initialize representative with footprints of simplices in current composition
-        composition_t representative { composition[0]->footprint_id(),
-                                       composition[1]->footprint_id(),
-                                       composition[2]->footprint_id() };
+        composition_t representative { composition[0]->footprint().id(),
+                                       composition[1]->footprint().id(),
+                                       composition[2]->footprint().id() };
 
         // pick a representative (factor out equivalence relation)
         std::sort(representative.begin(), representative.end());
@@ -165,10 +165,10 @@ namespace mito::topology {
         -> composition_t
     {
         // initialize representative with footprints of simplices in current composition
-        composition_t representative { composition[0]->footprint_id(),
-                                       composition[1]->footprint_id(),
-                                       composition[2]->footprint_id(),
-                                       composition[3]->footprint_id() };
+        composition_t representative { composition[0]->footprint().id(),
+                                       composition[1]->footprint().id(),
+                                       composition[2]->footprint().id(),
+                                       composition[3]->footprint().id() };
 
         // pick a representative (factor out equivalence relation)
         std::sort(representative.begin(), representative.end());

--- a/lib/mito/topology/forward1.h
+++ b/lib/mito/topology/forward1.h
@@ -35,14 +35,6 @@ namespace mito::topology {
     // topology alias
     using topology_t = Topology;
 
-    // id type of unoriented simplex
-    using unoriented_simplex_id_t = std::uintptr_t;
-
-    // id type of unoriented simplex
-    // QUESTION: should we collapse these two ids and call them {cell_id_t}?
-    using oriented_simplex_id_t = std::uintptr_t;
-
-
     // TOFIX: not sure if this type is useful in other places than {Mesh}
     // element set alias
     template <class cellT>
@@ -60,6 +52,14 @@ namespace mito::topology {
     // oriented simplex alias
     template <int D>
     using oriented_simplex_t = utilities::shared_ptr<OrientedSimplex<D>>;
+
+    // id type of unoriented simplex
+    template <int D>
+    using unoriented_simplex_id_t = utilities::index_t<unoriented_simplex_t<D>>;
+
+    // id type of unoriented simplex
+    template <int D>
+    using oriented_simplex_id_t = utilities::index_t<oriented_simplex_t<D>>;
 }
 
 

--- a/lib/mito/topology/utilities.h
+++ b/lib/mito/topology/utilities.h
@@ -21,7 +21,7 @@ namespace mito::topology {
     std::ostream & operator<<(std::ostream & os, const unoriented_simplex_t<D> & s)
     requires(D > 0)
     {
-        os << s.handle() << " composed of:" << std::endl;
+        os << s.id() << " composed of:" << std::endl;
         for (const auto & simplex : s->composition()) {
             std::cout << "\t" << simplex << std::endl;
         }
@@ -32,7 +32,7 @@ namespace mito::topology {
     template <>
     std::ostream & operator<<(std::ostream & os, const simplex_t<0> & s)
     {
-        os << "vertex: " << s->footprint().handle() << std::endl;
+        os << "vertex: " << s->footprint().id() << std::endl;
         return os;
     }
 

--- a/lib/mito/utilities/SharedPointer.h
+++ b/lib/mito/utilities/SharedPointer.h
@@ -21,9 +21,6 @@ namespace mito::utilities {
 
         // interface
       public:
-        // accessor for {handle}
-        inline auto handle() const -> handle_t;
-
         // returns the id of this (oriented) simplex
         inline auto id() const -> index_t<Resource>;
 
@@ -66,6 +63,9 @@ namespace mito::utilities {
         inline SharedPointer & operator=(SharedPointer<Resource> &&);
 
       private:
+        // accessor for {handle}
+        inline auto handle() const -> handle_t;
+
         // increment the reference count
         inline auto _acquire() const -> void;
         // decrement the reference count
@@ -86,13 +86,13 @@ namespace mito::utilities {
     template <class Resource>
     inline bool operator==(const SharedPointer<Resource> & lhs, const SharedPointer<Resource> & rhs)
     {
-        return lhs.handle() == rhs.handle();
+        return lhs.id() == rhs.id();
     }
 
     template <class Resource>
     inline bool operator<(const SharedPointer<Resource> & lhs, const SharedPointer<Resource> & rhs)
     {
-        return lhs.handle() < rhs.handle();
+        return lhs.id() < rhs.id();
     }
 }
 

--- a/lib/mito/utilities/SharedPointer.h
+++ b/lib/mito/utilities/SharedPointer.h
@@ -30,6 +30,9 @@ namespace mito::utilities {
         // reset the shared pointer
         inline auto reset() -> void;
 
+        // check if the handle is the null pointer
+        inline auto is_nullptr() const -> bool;
+
         // operator->
         auto operator->() const -> handle_t;
 

--- a/lib/mito/utilities/SharedPointer.h
+++ b/lib/mito/utilities/SharedPointer.h
@@ -24,6 +24,9 @@ namespace mito::utilities {
         // accessor for {handle}
         inline auto handle() const -> handle_t;
 
+        // returns the id of this (oriented) simplex
+        inline auto id() const -> index_t<Resource>;
+
         // accessor for the number of outstanding references
         inline auto references() const -> int;
 

--- a/lib/mito/utilities/SharedPointer.icc
+++ b/lib/mito/utilities/SharedPointer.icc
@@ -40,6 +40,14 @@ mito::utilities::SharedPointer<Resource>::reset() -> void
     return;
 }
 
+template <class Resource>
+auto
+mito::utilities::SharedPointer<Resource>::is_nullptr() const -> bool
+{
+    // all done
+    return _handle == nullptr;
+}
+
 // operator->
 template <class Resource>
 auto

--- a/lib/mito/utilities/SharedPointer.icc
+++ b/lib/mito/utilities/SharedPointer.icc
@@ -5,6 +5,14 @@
 #error This header file contains implementation details of class mito::utilities::SharedPointer
 #else
 
+template <class Resource>
+auto
+mito::utilities::SharedPointer<Resource>::id() const -> index_t<Resource>
+{
+    // the id is the (immutable) address of this object
+    return reinterpret_cast<index_t<Resource>>(_handle);
+}
+
 // interface
 template <class Resource>
 auto

--- a/lib/mito/utilities/forward.h
+++ b/lib/mito/utilities/forward.h
@@ -58,7 +58,7 @@ namespace mito::utilities {
         size_t operator()(const sharedPointerT & item) const
         {
             // reinterpret the address of the pointed handle as a {size_t} and return it
-            return reinterpret_cast<size_t>(item.handle());
+            return reinterpret_cast<size_t>(item.id());
         }
     };
 }

--- a/lib/mito/utilities/forward.h
+++ b/lib/mito/utilities/forward.h
@@ -21,6 +21,9 @@ namespace mito::utilities {
     template <class Resource>
     using shared_ptr = SharedPointer<Resource>;
 
+    template <class Resource>
+    using index_t = std::uintptr_t;
+
     // class segmented container
     template <class Resource>
     // requires ReferenceCountedObject<Resource>

--- a/tests/mito.lib/oriented-simplex/main.cc
+++ b/tests/mito.lib/oriented-simplex/main.cc
@@ -20,21 +20,18 @@ TEST(OrientedSimplex, TestOrientedSimplex)
         // instantiate an identical oriented segment
         auto & oriented_segment1 = topology.segment({ vertex0, vertex1 });
         // assert the factory returned the same oriented segment
-        EXPECT_TRUE(oriented_segment0->simplex_id() == oriented_segment1->simplex_id());
+        EXPECT_TRUE(oriented_segment0.id() == oriented_segment1.id());
         // assert there is still only one pointer to the simplex footprint
         EXPECT_FALSE(topology.exists_flipped(oriented_segment0));
         // assert that flipping the flipped simplex gives the original simplex
-        EXPECT_TRUE(
-            topology.flip(topology.flip(oriented_segment1))->simplex_id()
-            == oriented_segment1->simplex_id());
+        EXPECT_TRUE(topology.flip(topology.flip(oriented_segment1)).id() == oriented_segment1.id());
 
         // instantiate an oriented segment with opposite orientation
         auto & oriented_segment2 = topology.segment({ vertex1, vertex0 });
         // assert there are now two pointers to the simplex footprint
         EXPECT_TRUE(topology.exists_flipped(oriented_segment0));
         // assert that flipping the opposite segment gives the original segment
-        EXPECT_TRUE(
-            topology.flip(oriented_segment2)->simplex_id() == oriented_segment1->simplex_id());
+        EXPECT_TRUE(topology.flip(oriented_segment2).id() == oriented_segment1.id());
     }
     {
         // an empty topology
@@ -55,7 +52,7 @@ TEST(OrientedSimplex, TestOrientedSimplex)
         // ask factory for the same triangle (with different order of segments)
         auto & cell1 = topology.triangle({ segment_b, segment_c, segment_a });
         // assert the factory returned the same object
-        EXPECT_TRUE(cell0->simplex_id() == cell1->simplex_id());
+        EXPECT_TRUE(cell0.id() == cell1.id());
 
         // get the flipped segments
         auto & segment_a_flip = topology.flip(segment_a);    // vertex1 -> vertex0
@@ -64,11 +61,11 @@ TEST(OrientedSimplex, TestOrientedSimplex)
 
         // ask factory for a triangle with the flipped segments
         auto & cell2 = topology.triangle({ segment_a_flip, segment_c_flip, segment_b_flip });
-        EXPECT_TRUE(cell0->simplex_id() != cell2->simplex_id());
+        EXPECT_TRUE(cell0.id() != cell2.id());
 
         // get the flipped triangle
         auto & cell0_flip = topology.flip(cell0);
         // assert that the triangle with flipped segments is the same object as the flipped triangle
-        EXPECT_TRUE(cell0_flip->simplex_id() == cell2->simplex_id());
+        EXPECT_TRUE(cell0_flip.id() == cell2.id());
     }
 }


### PR DESCRIPTION
The underlying handle of instances of class `SharedPointer` should not be accessible outside the class, otherwise there is a mechanism to make 'un-reference-counted' references to `Shareable` objects.