### PR TITLE
Add {noexcept} specifier where appropriate

### DIFF
--- a/lib/mito/fem/NodalField.h
+++ b/lib/mito/fem/NodalField.h
@@ -46,13 +46,13 @@ namespace mito::fem {
         /**
          * Accessors
          */
-        inline const std::string & name() const { return _name; }
+        inline const std::string & name() const noexcept { return _name; }
 
-        inline int dim() const { return D; }
+        inline int dim() const noexcept { return D; }
 
-        inline int nodes() const { return _nodes; }
+        inline int nodes() const noexcept { return _nodes; }
 
-        inline int size() const { return _nodes * D; }
+        inline int size() const noexcept { return _nodes * D; }
 
         /**
          * Set the field to zero.

--- a/lib/mito/fem/QuadratureField.h
+++ b/lib/mito/fem/QuadratureField.h
@@ -84,17 +84,17 @@ namespace mito::fem {
          * accessor for the number of quadrature points per element
          * @return the number of quadrature point per element
          */
-        inline constexpr int n_quad_points() const { return Q; }
+        inline constexpr int n_quad_points() const noexcept { return Q; }
 
         /**
          * const accessor for name
          */
-        inline std::string name() const { return _name; }
+        inline std::string name() const noexcept { return _name; }
 
         /**
          * setter method for name
          */
-        inline void name(std::string name)
+        inline void name(std::string name) noexcept
         {
             _name = name;
             return;

--- a/lib/mito/geometry/Geometry.h
+++ b/lib/mito/geometry/Geometry.h
@@ -52,7 +52,7 @@ namespace mito::geometry {
         }
 
         // accessor to the collection of nodes
-        inline auto nodes() const -> const nodes_t<D> & { return _nodes; }
+        inline auto nodes() const noexcept -> const nodes_t<D> & { return _nodes; }
 
         // get the point in space associated to this vertex
         inline auto point(const vertex_t & vertex) const -> const point_t<D> &
@@ -61,10 +61,10 @@ namespace mito::geometry {
         }
 
         // accessor for topology
-        inline auto topology() -> topology_t & { return _topology; }
+        inline auto topology() noexcept -> topology_t & { return _topology; }
 
         // const accessor for topology
-        inline auto topology() const -> const topology_t & { return _topology; }
+        inline auto topology() const noexcept -> const topology_t & { return _topology; }
 
       private:
         // the collection of nodes

--- a/lib/mito/geometry/Node.h
+++ b/lib/mito/geometry/Node.h
@@ -17,10 +17,10 @@ namespace mito::geometry {
 
       public:
         // accessor for the underlying vertex
-        auto vertex() const -> const vertex_t & { return _vertex; }
+        auto vertex() const noexcept -> const vertex_t & { return _vertex; }
 
         // accessor for the underlying point
-        auto point() const -> const point_t & { return _point; }
+        auto point() const noexcept -> const point_t & { return _point; }
 
       private:
         // the vertex that this node is attached to
@@ -30,7 +30,7 @@ namespace mito::geometry {
     };
 
     template <int D>
-    inline bool operator==(const Node<D> & lhs, const Node<D> & rhs)
+    inline bool operator==(const Node<D> & lhs, const Node<D> & rhs) noexcept
     {
         return lhs.vertex() == rhs.vertex() && lhs.point() == rhs.point();
     }

--- a/lib/mito/geometry/Point.h
+++ b/lib/mito/geometry/Point.h
@@ -54,7 +54,7 @@ namespace mito::geometry {
     {
         // return the distance between the two points
         auto dist = pointA->coordinates() - pointB->coordinates();
-        return sqrt(dist * dist);
+        return std::sqrt(dist * dist);
     }
 
     template <int D>

--- a/lib/mito/geometry/Point.h
+++ b/lib/mito/geometry/Point.h
@@ -30,9 +30,9 @@ namespace mito::geometry {
 
       public:
         // get the coordinates of the point
-        auto coordinates() const -> const vector_t<D> & { return _coordinates; }
+        auto coordinates() const noexcept -> const vector_t<D> & { return _coordinates; }
 
-        auto print() const -> void
+        auto print() const noexcept -> void
         {
             // print the coordinates of the point
             std::cout << "Point: " << coordinates() << std::endl;
@@ -50,7 +50,7 @@ namespace mito::geometry {
     };
 
     template <int D>
-    auto distance(const point_t<D> & pointA, const point_t<D> & pointB) -> real
+    auto distance(const point_t<D> & pointA, const point_t<D> & pointB) noexcept -> real
     {
         // return the distance between the two points
         auto dist = pointA->coordinates() - pointB->coordinates();
@@ -58,7 +58,7 @@ namespace mito::geometry {
     }
 
     template <int D>
-    std::ostream & operator<<(std::ostream & os, const Point<D> & point)
+    std::ostream & operator<<(std::ostream & os, const Point<D> & point) noexcept
     {
         // print the point
         point.print();

--- a/lib/mito/geometry/PointCloud.h
+++ b/lib/mito/geometry/PointCloud.h
@@ -31,7 +31,7 @@ namespace mito::geometry {
         }
 
       public:
-        auto print() const -> void
+        auto print() const noexcept -> void
         {
             // iterate on points
             std::cout << "Point cloud:" << std::endl;
@@ -46,7 +46,7 @@ namespace mito::geometry {
         inline auto begin() -> const auto & { return std::cbegin(_cloud); }
         inline auto end() -> const auto & { return std::cend(_cloud); }
 
-        auto size() -> int { return std::size(_cloud); }
+        auto size() const noexcept -> int { return std::size(_cloud); }
 
         // example use: cloud.point({0.0, ..., 0.0})
         auto point(vector_t<D> && coord) -> const point_t<D> &
@@ -75,7 +75,7 @@ namespace mito::geometry {
             return it.first->second;
         }
 
-        auto compositions() const -> const point_compositions_t & { return _compositions; }
+        auto compositions() const noexcept -> const point_compositions_t & { return _compositions; }
 
       private:
         // the cloud of points
@@ -90,7 +90,7 @@ namespace mito::geometry {
     };
 
     template <int D>
-    std::ostream & operator<<(std::ostream & os, const PointCloud<D> & cloud)
+    std::ostream & operator<<(std::ostream & os, const PointCloud<D> & cloud) noexcept
     {
         // print the cloud
         cloud.print();

--- a/lib/mito/manifolds/Manifold.h
+++ b/lib/mito/manifolds/Manifold.h
@@ -72,8 +72,11 @@ namespace mito::manifolds {
             return check;
         }
 
-        inline auto elements() const -> const element_vector_t<cell_t> & { return _elements; }
-        inline auto nElements() const -> int { return std::size(_elements); }
+        inline auto elements() const noexcept -> const element_vector_t<cell_t> &
+        {
+            return _elements;
+        }
+        inline auto nElements() const noexcept -> int { return std::size(_elements); }
         inline auto jacobian(int e) const -> real { return _jacobians[e]; }
         inline auto coordinatesVertex(const vertex_t & v) const -> const vector_t<D> &
         {

--- a/lib/mito/manifolds/metrics.h
+++ b/lib/mito/manifolds/metrics.h
@@ -178,7 +178,7 @@ namespace mito::manifolds {
 
             // compute area of element e
             areas[e] = ((element->orientation() == true) ? 1 : -1) * 0.25
-                     * sqrt((a + bpc) * (c - amb) * (c + amb) * (a + bmc));
+                     * std::sqrt((a + bpc) * (c - amb) * (c + amb) * (a + bmc));
 
             // update elements counter
             ++e;

--- a/lib/mito/manifolds/parametric.h
+++ b/lib/mito/manifolds/parametric.h
@@ -2,22 +2,22 @@
 namespace mito::manifolds {
 
     template <class cellT>
-    constexpr auto parametric_dim() -> int;
+    constexpr auto parametric_dim() noexcept -> int;
 
     template <>
-    constexpr auto parametric_dim<topology::segment_t>() -> int
+    constexpr auto parametric_dim<topology::segment_t>() noexcept -> int
     {
         return 2;
     }
 
     template <>
-    constexpr auto parametric_dim<topology::triangle_t>() -> int
+    constexpr auto parametric_dim<topology::triangle_t>() noexcept -> int
     {
         return 3;
     }
 
     template <>
-    constexpr auto parametric_dim<topology::tetrahedron_t>() -> int
+    constexpr auto parametric_dim<topology::tetrahedron_t>() noexcept -> int
     {
         return 4;
     }

--- a/lib/mito/math/Field.h
+++ b/lib/mito/math/Field.h
@@ -41,7 +41,7 @@ namespace mito::math {
         // destructor
         constexpr ~Field() {}
 
-        constexpr auto operator()(const X & x) const
+        constexpr auto operator()(const X & x) const -> Y
         {
             // evaluate _f
             return _f(x);
@@ -49,10 +49,10 @@ namespace mito::math {
 
       public:
         // accessor for function
-        constexpr const auto & f() const noexcept { return _f; }
+        constexpr auto f() const noexcept -> const function_t<X, Y> & { return _f; }
 
         // accessor for function partial derivatives
-        constexpr const auto & Df(int i) const
+        constexpr auto Df(int i) const -> const function_t<X, Y> &
         {
             // assert there exists the i-th partial derivative
             assert(i < (int) std::size(_Df));
@@ -69,6 +69,7 @@ namespace mito::math {
 
     template <class X, class Y>
     constexpr auto operator+(const field_t<X, Y> & fieldA, const field_t<X, Y> & fieldB)
+        -> field_t<X, Y>
     {
         // dimension of the X space
         constexpr int D = size<X>::value;
@@ -88,7 +89,7 @@ namespace mito::math {
     // function to compute the gradient of a scalar field with respect to the reference
     // configuration at point x
     template <int D>
-    constexpr auto grad(const scalar_field_t<D> & field, const vector_t<D> & x)
+    constexpr auto grad(const scalar_field_t<D> & field, const vector_t<D> & x) -> vector_t<D>
     {
         // helper function to compute the gradient of a vector field with respect to the reference
         // configuration (template with index sequence)
@@ -104,7 +105,7 @@ namespace mito::math {
     // function to compute the gradient of a vector field with respect to the reference
     // configuration
     template <int D>
-    constexpr vector_field_t<D, D> grad(const scalar_field_t<D> & field)
+    constexpr auto grad(const scalar_field_t<D> & field) -> vector_field_t<D, D>
     {
         // helper function to compute the gradient of a vector field with respect to the reference
         // configuration (template with index sequence)
@@ -120,7 +121,7 @@ namespace mito::math {
 
     // function to compute the Divergence of a vector field at point X
     template <int D>
-    constexpr real div(const vector_field_t<D, D> & field, const vector_t<D> & X)
+    constexpr auto div(const vector_field_t<D, D> & field, const vector_t<D> & X) -> real
     {
         real result = 0.0;
         for (int i = 0; i < D; ++i) {
@@ -132,7 +133,7 @@ namespace mito::math {
     // function to compute the divergence of a vector field with respect to the reference
     // configuration at point X
     template <int D>
-    constexpr scalar_field_t<D> div(const vector_field_t<D, D> & field)
+    constexpr auto div(const vector_field_t<D, D> & field) -> scalar_field_t<D>
     {
         // helper function to compute the divergence of a vector field with respect to the reference
         // configuration at point X (template with index sequence)

--- a/lib/mito/math/Field.h
+++ b/lib/mito/math/Field.h
@@ -24,10 +24,10 @@ namespace mito::math {
         {}
 
         // default move constructor
-        constexpr Field(Field &&) = default;
+        constexpr Field(Field &&) noexcept = default;
 
         // default move operator=
-        constexpr Field & operator=(Field &&) = default;
+        constexpr Field & operator=(Field &&) noexcept = default;
 
         // default copy constructor
         constexpr Field(const Field &) = default;

--- a/lib/mito/math/Field.h
+++ b/lib/mito/math/Field.h
@@ -49,7 +49,7 @@ namespace mito::math {
 
       public:
         // accessor for function
-        constexpr const auto & f() const { return _f; }
+        constexpr const auto & f() const noexcept { return _f; }
 
         // accessor for function partial derivatives
         constexpr const auto & Df(int i) const

--- a/lib/mito/math/Function.h
+++ b/lib/mito/math/Function.h
@@ -23,13 +23,13 @@ namespace mito::math {
         // copy constructor
         constexpr Function(const Function &) = default;
         // move constructor
-        constexpr Function(Function &&) = default;
+        constexpr Function(Function &&) noexcept = default;
         // destructor
         constexpr ~Function() {};
         // assignment operator
         constexpr Function & operator=(const Function &) = default;
         // move operator=
-        constexpr Function & operator=(Function &&) = default;
+        constexpr Function & operator=(Function &&) noexcept = default;
 
         constexpr auto operator()(const X & x) const
         {

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -93,13 +93,13 @@ namespace mito::mesh {
             return true;
         }
 
-        inline auto nCells() const -> int
+        inline auto nCells() const noexcept -> int
         {
             // all done
             return std::size(_cells);
         }
 
-        inline auto cells() const -> const cells_t &
+        inline auto cells() const noexcept -> const cells_t &
         {
             // all done
             return _cells;
@@ -204,7 +204,7 @@ namespace mito::mesh {
 
       public:
         // accessor to geometry
-        auto geometry() const -> const geometry_t & { return _geometry; }
+        auto geometry() const noexcept -> const geometry_t & { return _geometry; }
 
       private:
         // a reference to the geometry where the cells are embedded

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -34,7 +34,7 @@ namespace mito::mesh {
         inline ~Mesh() {}
 
         // move constructor
-        inline Mesh(Mesh &&) = default;
+        inline Mesh(Mesh &&) noexcept = default;
 
       private:
         // delete copy constructor

--- a/lib/mito/topology/OrientedSimplex.h
+++ b/lib/mito/topology/OrientedSimplex.h
@@ -58,15 +58,18 @@ namespace mito::topology {
 
       public:
         // accessor for the unoriented footprint
-        inline auto footprint() const -> const unoriented_simplex_t<D> & { return _footprint; }
+        inline auto footprint() const noexcept -> const unoriented_simplex_t<D> &
+        {
+            return _footprint;
+        }
 
         // returns the orientation of this simplex
         // (true: oriented simplex is oriented as the footprint,
         //  false: oriented simplex is oriented opposite to the footprint)
-        inline auto orientation() const -> bool { return _orientation; }
+        inline auto orientation() const noexcept -> bool { return _orientation; }
 
         // returns the array of subsimplices
-        inline auto composition() const -> const simplex_composition_t<D> &
+        inline auto composition() const noexcept -> const simplex_composition_t<D> &
         {
             return _footprint->composition();
         }

--- a/lib/mito/topology/Simplex.h
+++ b/lib/mito/topology/Simplex.h
@@ -44,7 +44,10 @@ namespace mito::topology {
 
       public:
         // accessor for the subsimplices
-        inline auto composition() const -> const simplex_composition_t<D> & { return _simplices; }
+        inline auto composition() const noexcept -> const simplex_composition_t<D> &
+        {
+            return _simplices;
+        }
 
         // add the vertices of this simplex to a collection of vertices
         template <class VERTEX_COLLECTION_T>
@@ -142,7 +145,7 @@ namespace mito::topology {
 
       public:
         // perform a sanity check
-        inline auto sanityCheck() const -> bool
+        inline auto sanityCheck() const noexcept -> bool
         {
             // a simplex of order 0 has only 1 vertex (this one!)
             return true;

--- a/lib/mito/topology/Topology.h
+++ b/lib/mito/topology/Topology.h
@@ -89,11 +89,11 @@ namespace mito::topology {
 
         // mutator for the simplex factory of dimension D
         template <int D>
-        inline auto _get_factory() -> oriented_simplex_factory_t<D> &;
+        inline auto _get_factory() noexcept -> oriented_simplex_factory_t<D> &;
 
         // accessor for the simplex factory of dimension D
         template <int D>
-        inline auto _get_factory() const -> const oriented_simplex_factory_t<D> &;
+        inline auto _get_factory() const noexcept -> const oriented_simplex_factory_t<D> &;
 
       public:
         template <int D>

--- a/lib/mito/topology/Topology.icc
+++ b/lib/mito/topology/Topology.icc
@@ -15,56 +15,56 @@ mito::topology::Topology::~Topology() {};
 
 template <>
 inline auto
-mito::topology::Topology::_get_factory<0>() -> oriented_simplex_factory_t<0> &
+mito::topology::Topology::_get_factory<0>() noexcept -> oriented_simplex_factory_t<0> &
 {
     return _vertex_factory;
 }
 
 template <>
 inline auto
-mito::topology::Topology::_get_factory<1>() -> oriented_simplex_factory_t<1> &
+mito::topology::Topology::_get_factory<1>() noexcept -> oriented_simplex_factory_t<1> &
 {
     return _segment_factory;
 }
 
 template <>
 inline auto
-mito::topology::Topology::_get_factory<2>() -> oriented_simplex_factory_t<2> &
+mito::topology::Topology::_get_factory<2>() noexcept -> oriented_simplex_factory_t<2> &
 {
     return _triangle_factory;
 }
 
 template <>
 inline auto
-mito::topology::Topology::_get_factory<3>() -> oriented_simplex_factory_t<3> &
+mito::topology::Topology::_get_factory<3>() noexcept -> oriented_simplex_factory_t<3> &
 {
     return _tetrahedron_factory;
 }
 
 template <>
 inline auto
-mito::topology::Topology::_get_factory<0>() const -> const oriented_simplex_factory_t<0> &
+mito::topology::Topology::_get_factory<0>() const noexcept -> const oriented_simplex_factory_t<0> &
 {
     return _vertex_factory;
 }
 
 template <>
 inline auto
-mito::topology::Topology::_get_factory<1>() const -> const oriented_simplex_factory_t<1> &
+mito::topology::Topology::_get_factory<1>() const noexcept -> const oriented_simplex_factory_t<1> &
 {
     return _segment_factory;
 }
 
 template <>
 inline auto
-mito::topology::Topology::_get_factory<2>() const -> const oriented_simplex_factory_t<2> &
+mito::topology::Topology::_get_factory<2>() const noexcept -> const oriented_simplex_factory_t<2> &
 {
     return _triangle_factory;
 }
 
 template <>
 inline auto
-mito::topology::Topology::_get_factory<3>() const -> const oriented_simplex_factory_t<3> &
+mito::topology::Topology::_get_factory<3>() const noexcept -> const oriented_simplex_factory_t<3> &
 {
     return _tetrahedron_factory;
 }

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -190,7 +190,7 @@ namespace mito::utilities {
         }
 
       public:
-        auto segment_size() const -> int { return _segment_size; }
+        auto segment_size() const noexcept -> int { return _segment_size; }
 
         auto location_for_placement() -> T *
         {

--- a/lib/mito/utilities/SegmentedContainerIterator.h
+++ b/lib/mito/utilities/SegmentedContainerIterator.h
@@ -64,14 +64,14 @@ namespace mito::utilities {
         }
 
         // accessors
-        constexpr auto ptr() const -> pointer
+        constexpr auto ptr() const noexcept -> pointer
         {
             // easy enough
             return _ptr;
         }
 
         // operator->
-        constexpr auto operator->() const -> pointer
+        constexpr auto operator->() const noexcept -> pointer
         {
             // return the pointer
             return ptr();
@@ -157,7 +157,7 @@ namespace mito::utilities {
     template <class SegmentedContainerT, bool isConst>
     constexpr auto operator==(
         const SegmentedContainerIterator<SegmentedContainerT, isConst> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) -> bool
+        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) noexcept -> bool
     {
         // iterators are equal if they point to the same segmented container
         return it1.ptr() == it2.ptr();
@@ -167,7 +167,7 @@ namespace mito::utilities {
     template <class SegmentedContainerT, bool isConst>
     constexpr auto operator!=(
         const SegmentedContainerIterator<SegmentedContainerT, isConst> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) -> bool
+        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) noexcept -> bool
     {
         // iterators are unequal iff they are not equal
         return !(it1 == it2);

--- a/lib/mito/utilities/SegmentedContainerIterator.h
+++ b/lib/mito/utilities/SegmentedContainerIterator.h
@@ -145,10 +145,11 @@ namespace mito::utilities {
         ~SegmentedContainerIterator() = default;
         // let the compiler write the rest
         constexpr SegmentedContainerIterator(const SegmentedContainerIterator &) = default;
-        constexpr SegmentedContainerIterator(SegmentedContainerIterator &&) = default;
+        constexpr SegmentedContainerIterator(SegmentedContainerIterator &&) noexcept = default;
         constexpr SegmentedContainerIterator & operator=(const SegmentedContainerIterator &) =
             default;
-        constexpr SegmentedContainerIterator & operator=(SegmentedContainerIterator &&) = default;
+        constexpr SegmentedContainerIterator & operator=(SegmentedContainerIterator &&) noexcept =
+            default;
     };
 
     // the global operators

--- a/lib/mito/utilities/Shareable.h
+++ b/lib/mito/utilities/Shareable.h
@@ -14,7 +14,7 @@ namespace mito::utilities {
         // interface
       public:
         // whether the resource is valid or not
-        inline auto is_valid() const -> bool;
+        inline auto is_valid() const noexcept -> bool;
 
         // meta methods
       public:
@@ -40,11 +40,11 @@ namespace mito::utilities {
 
       private:
         // accessor for the number of outstanding references
-        inline auto _references() const -> int;
+        inline auto _references() const noexcept -> int;
         // increment the reference count
-        inline auto _acquire() const -> int;
+        inline auto _acquire() const noexcept -> int;
         // decrement the reference count
-        inline auto _release() const -> int;
+        inline auto _release() const noexcept -> int;
 
         // data members
       private:

--- a/lib/mito/utilities/Shareable.icc
+++ b/lib/mito/utilities/Shareable.icc
@@ -7,7 +7,7 @@
 
 // interface
 auto
-mito::utilities::Shareable::is_valid() const -> bool
+mito::utilities::Shareable::is_valid() const noexcept -> bool
 {
     // true unless the references count is negative or zero
     return (_reference_count > 0 ? true : false);
@@ -20,21 +20,21 @@ constexpr mito::utilities::Shareable::~Shareable() {}
 constexpr mito::utilities::Shareable::Shareable() : _reference_count(0) {}
 
 auto
-mito::utilities::Shareable::_references() const -> int
+mito::utilities::Shareable::_references() const noexcept -> int
 {
     // return the count of outstanding references
     return _reference_count;
 }
 
 auto
-mito::utilities::Shareable::_acquire() const -> int
+mito::utilities::Shareable::_acquire() const noexcept -> int
 {
     // increment the reference count and return it
     return ++_reference_count;
 }
 
 auto
-mito::utilities::Shareable::_release() const -> int
+mito::utilities::Shareable::_release() const noexcept -> int
 {
     // decrement the reference count and return it
     return --_reference_count;

--- a/lib/mito/utilities/SharedPointer.h
+++ b/lib/mito/utilities/SharedPointer.h
@@ -31,10 +31,10 @@ namespace mito::utilities {
         inline auto reset() -> void;
 
         // check if the handle is the null pointer
-        inline auto is_nullptr() const -> bool;
+        inline auto is_nullptr() const noexcept -> bool;
 
         // operator->
-        auto operator->() const -> handle_t;
+        auto operator->() const noexcept -> handle_t;
 
         // // operator*
         // auto operator*() const -> const resource_t &;
@@ -54,7 +54,7 @@ namespace mito::utilities {
         inline SharedPointer(const SharedPointer<Resource> &);
 
         // move constructor
-        inline SharedPointer(SharedPointer<Resource> &&);
+        inline SharedPointer(SharedPointer<Resource> &&) noexcept;
 
         // assignment operator
         inline SharedPointer & operator=(const SharedPointer<Resource> &);
@@ -64,7 +64,7 @@ namespace mito::utilities {
 
       private:
         // accessor for {handle}
-        inline auto handle() const -> handle_t;
+        inline auto handle() const noexcept -> handle_t;
 
         // returns the resource corresponding to this resource id
         static inline auto resource(index_t<Resource>) -> handle_t;

--- a/lib/mito/utilities/SharedPointer.icc
+++ b/lib/mito/utilities/SharedPointer.icc
@@ -24,7 +24,7 @@ mito::utilities::SharedPointer<Resource>::resource(index_t<Resource> index) -> h
 // interface
 template <class Resource>
 auto
-mito::utilities::SharedPointer<Resource>::handle() const
+mito::utilities::SharedPointer<Resource>::handle() const noexcept
     -> mito::utilities::SharedPointer<Resource>::handle_t
 {
     // return the handle
@@ -58,7 +58,7 @@ mito::utilities::SharedPointer<Resource>::reset() -> void
 
 template <class Resource>
 auto
-mito::utilities::SharedPointer<Resource>::is_nullptr() const -> bool
+mito::utilities::SharedPointer<Resource>::is_nullptr() const noexcept -> bool
 {
     // all done
     return _handle == nullptr;
@@ -67,7 +67,7 @@ mito::utilities::SharedPointer<Resource>::is_nullptr() const -> bool
 // operator->
 template <class Resource>
 auto
-mito::utilities::SharedPointer<Resource>::operator->() const
+mito::utilities::SharedPointer<Resource>::operator->() const noexcept
     -> mito::utilities::SharedPointer<Resource>::handle_t
 {
     // return the handle
@@ -122,7 +122,7 @@ mito::utilities::SharedPointer<Resource>::SharedPointer(
 // the move constructor
 template <class Resource>
 mito::utilities::SharedPointer<Resource>::SharedPointer(
-    mito::utilities::SharedPointer<Resource> && other) :
+    mito::utilities::SharedPointer<Resource> && other) noexcept :
     _handle(other._handle),
     _container(other._container)
 {

--- a/lib/mito/utilities/forward.h
+++ b/lib/mito/utilities/forward.h
@@ -42,14 +42,14 @@ namespace mito::utilities {
     template <class SegmentedContainerT, bool isConst>
     constexpr auto operator==(
         const SegmentedContainerIterator<SegmentedContainerT, isConst> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) -> bool;
+        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) noexcept -> bool;
 
 
     // and not
     template <class SegmentedContainerT, bool isConst>
     constexpr auto operator!=(
         const SegmentedContainerIterator<SegmentedContainerT, isConst> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) -> bool;
+        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) noexcept -> bool;
 
     // hash function for shared pointers
     // Note that two pointers pointing to the same cell collapse on the same hashed value

--- a/sandbox/sample-class/test.cpp
+++ b/sandbox/sample-class/test.cpp
@@ -11,7 +11,7 @@ class Simplex {
     // inline Simplex(const Simplex &) = delete;
 
     // move constructor
-    inline Simplex(Simplex &&) = default;
+    inline Simplex(Simplex &&) noexcept = default;
     // inline Simplex(const Simplex &&) = delete;
 
     // assignment operator
@@ -19,7 +19,7 @@ class Simplex {
     // inline const Simplex & operator=(const Simplex &) = delete;
 
     // move operator=
-    inline Simplex & operator=(Simplex &&) = default;
+    inline Simplex & operator=(Simplex &&) noexcept = default;
     // inline const Simplex & operator=(const Simplex &&) = delete;
 };
 


### PR DESCRIPTION
{noexcept} specifier has been added conservatively to move constructors, move assignment operators, getters and print methods. More methods can be marked as {noexcept} when we have a solid exceptions handling in place.

Closes #34.