### PR TITLE
Refactoring mito utilities

### DIFF
--- a/lib/mito/geometry/Geometry.h
+++ b/lib/mito/geometry/Geometry.h
@@ -36,13 +36,13 @@ namespace mito::geometry {
         }
 
         // instantiate a new vertex and a new point at {coord} and bind them into a node
-        inline auto node(vector_t<D> && coord) -> const vertex_t &
+        inline auto node(vector_t<D> && coord) -> vertex_t
         {
             // ask the topology for a new vertex
-            auto & vertex = _topology.vertex();
+            auto vertex = _topology.vertex();
 
             // ask the point cloud for a point with coordinates {coord}
-            auto & point = _point_cloud.point(std::move(coord));
+            auto point = _point_cloud.point(std::move(coord));
 
             // register the node with the geometry
             _nodes.emplace(node_t<D>(vertex, point));
@@ -55,7 +55,7 @@ namespace mito::geometry {
         inline auto nodes() const noexcept -> const nodes_t<D> & { return _nodes; }
 
         // get the point in space associated to this vertex
-        inline auto point(const vertex_t & vertex) const -> const point_t<D> &
+        inline auto point(const vertex_t & vertex) const -> point_t<D>
         {
             return _nodes.find(vertex)->second;
         }

--- a/lib/mito/geometry/Point.h
+++ b/lib/mito/geometry/Point.h
@@ -43,7 +43,7 @@ namespace mito::geometry {
 
       private:
         // the coordinates of the point
-        vector_t<D> _coordinates;
+        const vector_t<D> _coordinates;
 
         // private friendship with the point cloud
         friend class PointCloud<D>;

--- a/lib/mito/geometry/Point.h
+++ b/lib/mito/geometry/Point.h
@@ -9,12 +9,12 @@ namespace mito::geometry {
     class Point : public utilities::Shareable {
       private:
         template <class... Args>
-        Point(Args &&... args)
+        constexpr Point(Args &&... args)
         requires(sizeof...(Args) == D)
             : _coordinates(args...)
         {}
 
-        ~Point() override {}
+        constexpr ~Point() override {}
 
         // delete copy constructor
         Point(const Point &) = delete;
@@ -30,7 +30,7 @@ namespace mito::geometry {
 
       public:
         // get the coordinates of the point
-        auto coordinates() const noexcept -> const vector_t<D> & { return _coordinates; }
+        constexpr auto coordinates() const noexcept -> const vector_t<D> & { return _coordinates; }
 
         auto print() const noexcept -> void
         {
@@ -50,7 +50,7 @@ namespace mito::geometry {
     };
 
     template <int D>
-    auto distance(const point_t<D> & pointA, const point_t<D> & pointB) noexcept -> real
+    constexpr auto distance(const point_t<D> & pointA, const point_t<D> & pointB) noexcept -> real
     {
         // return the distance between the two points
         auto dist = pointA->coordinates() - pointB->coordinates();

--- a/lib/mito/geometry/Point.h
+++ b/lib/mito/geometry/Point.h
@@ -46,7 +46,7 @@ namespace mito::geometry {
         const vector_t<D> _coordinates;
 
         // private friendship with the repository of points
-        friend class utilities::Repository<Point<D>>;
+        friend class utilities::Repository<point_t<D>>;
     };
 
     template <int D>

--- a/lib/mito/geometry/Point.h
+++ b/lib/mito/geometry/Point.h
@@ -45,8 +45,8 @@ namespace mito::geometry {
         // the coordinates of the point
         const vector_t<D> _coordinates;
 
-        // private friendship with the point cloud
-        friend class PointCloud<D>;
+        // private friendship with the repository of points
+        friend class utilities::Repository<Point<D>>;
     };
 
     template <int D>

--- a/lib/mito/geometry/PointCloud.h
+++ b/lib/mito/geometry/PointCloud.h
@@ -31,8 +31,8 @@ namespace mito::geometry {
         {
             // iterate on points
             std::cout << "Point cloud:" << std::endl;
-            for (const auto & pPointMap : _compositions) {
-                std::cout << _cloud.resource(pPointMap.second)->coordinates() << std::endl;
+            for (const auto & point : _cloud) {
+                std::cout << point->coordinates() << std::endl;
             }
             // all done
             return;
@@ -66,7 +66,8 @@ namespace mito::geometry {
             return point;
         }
 
-        auto compositions() const noexcept -> const point_compositions_t & { return _compositions; }
+        // the iterable repository of the points in the cloud
+        auto points() const noexcept -> const cloud_t & { return _cloud; }
 
       private:
         // the cloud of points

--- a/lib/mito/geometry/PointCloud.h
+++ b/lib/mito/geometry/PointCloud.h
@@ -7,7 +7,8 @@ namespace mito::geometry {
     template <int D>
     class PointCloud {
       private:
-        using cloud_t = geometry::cloud_t<D>;
+        // a cloud of points
+        using cloud_t = utilities::repository_t<point_t<D>>;
         // id type of point
         using point_id_t = utilities::index_t<point_t<D>>;
         // TOFIX: make this unordered?

--- a/lib/mito/geometry/PointCloud.h
+++ b/lib/mito/geometry/PointCloud.h
@@ -38,12 +38,10 @@ namespace mito::geometry {
         }
 
         // support for ranged for loops (wrapping grid)
-        // TOFIX: define iterators on {Repository} so we can return simply
-        // std::cbegin(_cloud), ...
-        inline auto begin() -> const auto & { return std::cbegin(_cloud.resources()); }
-        inline auto end() -> const auto & { return std::cend(_cloud.resources()); }
+        inline auto begin() -> const auto & { return std::cbegin(_cloud); }
+        inline auto end() -> const auto & { return std::cend(_cloud); }
 
-        auto size() const noexcept -> int { return std::size(_cloud.resources()); }
+        auto size() const noexcept -> int { return std::size(_cloud); }
 
         // example use: cloud.point({0.0, ..., 0.0})
         auto point(vector_t<D> && coord) -> point_t<D>

--- a/lib/mito/geometry/PointCloud.h
+++ b/lib/mito/geometry/PointCloud.h
@@ -8,8 +8,10 @@ namespace mito::geometry {
     class PointCloud {
       private:
         using cloud_t = geometry::cloud_t<D>;
+        // id type of point
+        using point_id_t = utilities::index_t<point_t<D>>;
         // TOFIX: make this unordered?
-        using point_compositions_t = std::map<vector_t<D>, point_t<D>>;
+        using point_compositions_t = std::map<vector_t<D>, point_id_t>;
 
       private:
         PointCloud() : _cloud(100 /*segment size */), _compositions() {}
@@ -29,7 +31,7 @@ namespace mito::geometry {
             // iterate on points
             std::cout << "Point cloud:" << std::endl;
             for (const auto & pPointMap : _compositions) {
-                std::cout << pPointMap.second->coordinates() << std::endl;
+                std::cout << _cloud.resource(pPointMap.second)->coordinates() << std::endl;
             }
             // all done
             return;
@@ -44,7 +46,7 @@ namespace mito::geometry {
         auto size() const noexcept -> int { return std::size(_cloud.resources()); }
 
         // example use: cloud.point({0.0, ..., 0.0})
-        auto point(vector_t<D> && coord) -> point_t<D> &
+        auto point(vector_t<D> && coord) -> point_t<D>
         {
             // helper function to convert vector_t to variadic template argument
             auto _emplace_point = [this]<size_t... I>(
@@ -59,10 +61,10 @@ namespace mito::geometry {
             auto point = _emplace_point(coord, std::make_index_sequence<D> {});
 
             // register it in the compositions map
-            auto it = _compositions.insert(std::make_pair(point->coordinates(), point));
+            _compositions.insert(std::make_pair(point->coordinates(), point.id()));
 
             // return the newly added point
-            return it.first->second;
+            return point;
         }
 
         auto compositions() const noexcept -> const point_compositions_t & { return _compositions; }
@@ -71,6 +73,7 @@ namespace mito::geometry {
         // the cloud of points
         cloud_t _cloud;
 
+        // TOFIX: perhaps this container is unused?
         // the container mapping the composition of points to the points themselves
         point_compositions_t _compositions;
 

--- a/lib/mito/geometry/PointCloud.h
+++ b/lib/mito/geometry/PointCloud.h
@@ -11,11 +11,9 @@ namespace mito::geometry {
         using cloud_t = utilities::repository_t<point_t<D>>;
         // id type of point
         using point_id_t = utilities::index_t<point_t<D>>;
-        // TOFIX: make this unordered?
-        using point_compositions_t = std::map<vector_t<D>, point_id_t>;
 
       private:
-        PointCloud() : _cloud(100 /*segment size */), _compositions() {}
+        PointCloud() : _cloud(100 /*segment size */) {}
 
         // delete copy constructor
         PointCloud(const PointCloud<D> &) = delete;
@@ -59,9 +57,6 @@ namespace mito::geometry {
             // emplace point in {_cloud}
             auto point = _emplace_point(coord, std::make_index_sequence<D> {});
 
-            // register it in the compositions map
-            _compositions.insert(std::make_pair(point->coordinates(), point.id()));
-
             // return the newly added point
             return point;
         }
@@ -72,10 +67,6 @@ namespace mito::geometry {
       private:
         // the cloud of points
         cloud_t _cloud;
-
-        // TOFIX: perhaps this container is unused?
-        // the container mapping the composition of points to the points themselves
-        point_compositions_t _compositions;
 
         // friendship with the singleton
         using PointCloudSingleton = utilities::Singleton<PointCloud<D>>;

--- a/lib/mito/geometry/PointCloud.h
+++ b/lib/mito/geometry/PointCloud.h
@@ -62,7 +62,7 @@ namespace mito::geometry {
                 Point<D> * resource = new (location) Point<D>(coord[I]...);
 
                 // wrap the new point in a shared pointer and return it
-                return utilities::shared_ptr<Point<D>>(resource, &_cloud);
+                return utilities::shared_ptr<Point<D>>(resource);
             };
 
             // emplace point in {_cloud}

--- a/lib/mito/geometry/forward.h
+++ b/lib/mito/geometry/forward.h
@@ -29,9 +29,10 @@ namespace mito::geometry {
     template <int D>
     using geometry_t = Geometry<D>;
 
+    // TOFIX: do we need this typedef here?
     // a cloud of points
     template <int D>
-    using cloud_t = utilities::segmented_t<point_t<D>>;
+    using cloud_t = utilities::repository_t<typename point_t<D>::resource_t>;
 
     // class node
     template <int D>

--- a/lib/mito/geometry/forward.h
+++ b/lib/mito/geometry/forward.h
@@ -11,7 +11,7 @@ namespace mito::geometry {
 
     // point alias
     template <int D>
-    using point_t = utilities::shared_ptr<Point<D>>;
+    using point_t = utilities::shared_ptr<const Point<D>>;
 
     // class point cloud
     template <int D>

--- a/lib/mito/geometry/forward.h
+++ b/lib/mito/geometry/forward.h
@@ -29,11 +29,6 @@ namespace mito::geometry {
     template <int D>
     using geometry_t = Geometry<D>;
 
-    // TOFIX: do we need this typedef here?
-    // a cloud of points
-    template <int D>
-    using cloud_t = utilities::repository_t<point_t<D>>;
-
     // class node
     template <int D>
     class Node;

--- a/lib/mito/geometry/forward.h
+++ b/lib/mito/geometry/forward.h
@@ -32,7 +32,7 @@ namespace mito::geometry {
     // TOFIX: do we need this typedef here?
     // a cloud of points
     template <int D>
-    using cloud_t = utilities::repository_t<typename point_t<D>::resource_t>;
+    using cloud_t = utilities::repository_t<point_t<D>>;
 
     // class node
     template <int D>

--- a/lib/mito/geometry/utilities.h
+++ b/lib/mito/geometry/utilities.h
@@ -16,7 +16,7 @@ namespace mito::geometry {
         for (const auto & vertex : cell->vertices()) {
             result += geometry.point(vertex)->coordinates();
         }
-        result /= cellT::resource_type::n_vertices;
+        result /= topology::n_vertices<cellT>();
 
         // all done
         return result;

--- a/lib/mito/geometry/utilities.h
+++ b/lib/mito/geometry/utilities.h
@@ -16,7 +16,7 @@ namespace mito::geometry {
         for (const auto & vertex : cell->vertices()) {
             result += geometry.point(vertex)->coordinates();
         }
-        result /= cellT::resource_t::n_vertices;
+        result /= cellT::resource_type::n_vertices;
 
         // all done
         return result;

--- a/lib/mito/io/vtk/writer.h
+++ b/lib/mito/io/vtk/writer.h
@@ -132,7 +132,7 @@ namespace mito::io::vtk {
     auto writer(std::string fileName, const geometry::point_cloud_t<D> & cloud) -> void
     {
         // get point cloud compositions
-        const auto & compositions = cloud.compositions();
+        const auto & points = cloud.points();
 
         // vtk unstructured grid
         auto gridVtk = vtkSmartPointer<vtkUnstructuredGrid>::New();
@@ -140,8 +140,8 @@ namespace mito::io::vtk {
         auto pointsVtk = vtkSmartPointer<vtkPoints>::New();
 
         // iterate over the points
-        for (const auto & pPointMap : compositions) {
-            insertVtkPoint(pPointMap.first, pointsVtk);
+        for (const auto & point : points) {
+            insertVtkPoint(point->coordinates(), pointsVtk);
         }
 
         // set the grid points

--- a/lib/mito/io/vtk/writer.h
+++ b/lib/mito/io/vtk/writer.h
@@ -26,7 +26,10 @@ namespace mito::io::vtk {
     }
 
     template <int D>
-    auto insertVtkPoint(const vector_t<D> & coord, vtkSmartPointer<vtkPoints> & pointsVtk) -> void
+    auto insertVtkPoint(const vector_t<D> &, vtkSmartPointer<vtkPoints> &) -> void;
+
+    template <>
+    auto insertVtkPoint(const vector_t<3> & coord, vtkSmartPointer<vtkPoints> & pointsVtk) -> void
     {
         // add the point as new vtk point
         pointsVtk->InsertNextPoint(coord[0], coord[1], coord[2]);

--- a/lib/mito/io/vtk/writer.h
+++ b/lib/mito/io/vtk/writer.h
@@ -26,23 +26,17 @@ namespace mito::io::vtk {
     }
 
     template <int D>
-    auto insertVtkPoint(const geometry::point_t<D> & pPoint, vtkSmartPointer<vtkPoints> & pointsVtk)
-        -> void
+    auto insertVtkPoint(const vector_t<D> & coord, vtkSmartPointer<vtkPoints> & pointsVtk) -> void
     {
-        // retrieve the coordinates of the point
-        const auto & coordinates = pPoint->coordinates();
         // add the point as new vtk point
-        pointsVtk->InsertNextPoint(coordinates[0], coordinates[1], coordinates[2]);
+        pointsVtk->InsertNextPoint(coord[0], coord[1], coord[2]);
     }
 
     template <>
-    auto insertVtkPoint(const geometry::point_t<2> & pPoint, vtkSmartPointer<vtkPoints> & pointsVtk)
-        -> void
+    auto insertVtkPoint(const vector_t<2> & coord, vtkSmartPointer<vtkPoints> & pointsVtk) -> void
     {
-        // retrieve the coordinates of the point
-        const auto & coordinates = pPoint->coordinates();
         // add the point as new vtk point
-        pointsVtk->InsertNextPoint(coordinates[0], coordinates[1], 0.);
+        pointsVtk->InsertNextPoint(coord[0], coord[1], 0.);
     }
 
     template <class cellT, int D>
@@ -82,7 +76,7 @@ namespace mito::io::vtk {
                 // if the point is not present in the map
                 if (mapPoints.count(pPoint) == 0) {
                     // insert the new vtk point
-                    insertVtkPoint(pPoint, pointsVtk);
+                    insertVtkPoint(pPoint->coordinates(), pointsVtk);
                     // add the point to the map with its global index
                     mapPoints[pPoint] = indexPointVtk;
                     // update global index for the vtk point
@@ -144,7 +138,7 @@ namespace mito::io::vtk {
 
         // iterate over the points
         for (const auto & pPointMap : compositions) {
-            insertVtkPoint(pPointMap.second, pointsVtk);
+            insertVtkPoint(pPointMap.first, pointsVtk);
         }
 
         // set the grid points

--- a/lib/mito/manifolds/Manifold.h
+++ b/lib/mito/manifolds/Manifold.h
@@ -20,7 +20,7 @@ namespace mito::manifolds {
         // typedef for cell type
         using cell_t = cellT;
         // get the order of the cell
-        static constexpr int N = cellT::resource_type::order;
+        static constexpr int N = topology::order<cellT>();
         // a point in parametric coordinates
         static constexpr int parametricDim = parametric_dim<cell_t>();
         using parametric_point_t = manifolds::parametric_point_t<parametricDim>;

--- a/lib/mito/manifolds/Manifold.h
+++ b/lib/mito/manifolds/Manifold.h
@@ -20,7 +20,7 @@ namespace mito::manifolds {
         // typedef for cell type
         using cell_t = cellT;
         // get the order of the cell
-        static constexpr int N = cellT::resource_t::order;
+        static constexpr int N = cellT::resource_type::order;
         // a point in parametric coordinates
         static constexpr int parametricDim = parametric_dim<cell_t>();
         using parametric_point_t = manifolds::parametric_point_t<parametricDim>;

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -118,21 +118,23 @@ namespace mito::mesh {
 
         inline auto erase(const cell_type & cell) -> void
         {
-            // loop on the subcells of {cell}
-            for (const auto & subcell : cell->composition()) {
-                // decrement the orientations count for this cell footprint id, depending on the
-                // orientation
-                (subcell->orientation() ? _orientations[subcell->footprint().id()][0] -= 1 :
-                                          _orientations[subcell->footprint().id()][1] -= 1);
+            // erase the cell from the mesh
+            bool cell_was_erased = _cells.erase(cell);
+            // if the cell was in fact erased from the cell
+            if (cell_was_erased) {
+                // loop on the subcells of {cell}
+                for (const auto & subcell : cell->composition()) {
+                    // decrement the orientations count for this cell footprint id, depending on the
+                    // orientation
+                    (subcell->orientation() ? _orientations[subcell->footprint().id()][0] -= 1 :
+                                              _orientations[subcell->footprint().id()][1] -= 1);
 
-                // cleanup orientation map
-                if (_orientations[subcell->footprint().id()] == std::array<int, 2> { 0, 0 }) {
-                    _orientations.erase(subcell->footprint().id());
+                    // cleanup orientation map
+                    if (_orientations[subcell->footprint().id()] == std::array<int, 2> { 0, 0 }) {
+                        _orientations.erase(subcell->footprint().id());
+                    }
                 }
             }
-
-            // erase the cell from the mesh
-            _cells.erase(cell);
 
             // all done
             return;

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -16,7 +16,7 @@ namespace mito::mesh {
         // publish the dimension of physical space
         static constexpr int dim = D;
         // typedef for cell type
-        using cell_t = cellT;
+        using cell_type = cellT;
 
       private:
         // get the order of the cell
@@ -27,9 +27,9 @@ namespace mito::mesh {
         // typedef for geometry type
         using geometry_t = geometry::geometry_t<D>;
         // typedef for a collection of cells
-        using cells_t = element_set_t<cell_t>;
+        using cells_t = element_set_t<cell_type>;
         // id type of unoriented cell
-        using unoriented_cell_id_t = utilities::index_t<cell_t>;
+        using unoriented_cell_id_t = utilities::index_t<cell_type>;
         // this map maps a simplex id to a tuple of two integers counting how many times a simplex
         // appears with - or + orientation
         using orientation_map_t = std::unordered_map<unoriented_cell_id_t, std::array<int, 2>>;
@@ -114,7 +114,7 @@ namespace mito::mesh {
             return _cells;
         }
 
-        inline auto erase(const cell_t & cell) -> void
+        inline auto erase(const cell_type & cell) -> void
         {
             // loop on the subcells of {cell}
             for (const auto & subcell : cell->composition()) {
@@ -205,7 +205,7 @@ namespace mito::mesh {
             return boundary_mesh;
         }
 
-        inline auto insert(const cell_t & cell) -> void
+        inline auto insert(const cell_type & cell) -> void
         requires(N >= 1)
         {
             // add the cell to the set of cells with same dimension
@@ -225,7 +225,7 @@ namespace mito::mesh {
 
         // QUESTION: specialization of method {insert} for a mesh of vertices
         //           not sure if supporting meshes of 0-simplices makes sense...
-        inline auto insert(const cell_t & cell) -> void
+        inline auto insert(const cell_type & cell) -> void
         requires(N == 0)
         {
             // add the cell to the set of cells with same dimension

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -28,10 +28,11 @@ namespace mito::mesh {
         using geometry_t = geometry::geometry_t<D>;
         // typedef for a collection of cells
         using cells_t = element_set_t<cell_t>;
+        // id type of unoriented cell
+        using unoriented_cell_id_t = utilities::index_t<cell_t>;
         // this map maps a simplex id to a tuple of two integers counting how many times a simplex
         // appears with - or + orientation
-        using orientation_map_t =
-            std::unordered_map<topology::unoriented_simplex_id_t<D>, std::array<int, 2>>;
+        using orientation_map_t = std::unordered_map<unoriented_cell_id_t, std::array<int, 2>>;
 
       public:
         // default constructor

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -10,9 +10,9 @@ namespace mito::mesh {
 
       public:
         // publish the order of the cell
-        static constexpr int order = cellT::resource_t::order;
+        static constexpr int order = cellT::resource_type::order;
         // publish the number of vertices per element
-        static constexpr int n_vertices = cellT::resource_t::n_vertices;
+        static constexpr int n_vertices = cellT::resource_type::n_vertices;
         // publish the dimension of physical space
         static constexpr int dim = D;
         // typedef for cell type
@@ -20,10 +20,10 @@ namespace mito::mesh {
 
       private:
         // get the order of the cell
-        static constexpr int N = cellT::resource_t::order;
+        static constexpr int N = cellT::resource_type::order;
         // get the family this cell type belongs to (e.g. simplicial cells)
         template <int I>
-        using cell_family_t = typename cellT::resource_t::template cell_family_t<I>;
+        using cell_family_t = typename cellT::resource_type::template cell_family_t<I>;
         // typedef for geometry type
         using geometry_t = geometry::geometry_t<D>;
         // typedef for a collection of cells

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -23,20 +23,20 @@ namespace mito::mesh {
         static constexpr int N = order;
         // get the family this cell type belongs to (e.g. simplicial cells)
         template <int I>
-        using cell_family_t = typename topology::cell_family<cellT, I>;
+        using cell_family_type = typename topology::cell_family<cellT, I>;
         // typedef for geometry type
-        using geometry_t = geometry::geometry_t<D>;
+        using geometry_type = geometry::geometry_t<D>;
         // typedef for a collection of cells
-        using cells_t = element_set_t<cell_type>;
+        using cells_type = element_set_t<cell_type>;
         // id type of unoriented cell
-        using unoriented_cell_id_t = utilities::index_t<cell_type>;
+        using cell_id_type = utilities::index_t<cell_type>;
         // this map maps a simplex id to a tuple of two integers counting how many times a simplex
         // appears with - or + orientation
-        using orientation_map_t = std::unordered_map<unoriented_cell_id_t, std::array<int, 2>>;
+        using orientation_map_type = std::unordered_map<cell_id_type, std::array<int, 2>>;
 
       public:
         // default constructor
-        inline Mesh(const geometry_t & geometry)
+        inline Mesh(const geometry_type & geometry)
         requires(N <= D)
             : _geometry(geometry), _cells() {};
 
@@ -58,7 +58,8 @@ namespace mito::mesh {
       private:
         template <int I, int J>
         inline auto _insert_subcells(
-            Mesh<cell_family_t<I>, D> & boundary_mesh, const cell_family_t<J> & cell) const -> void
+            Mesh<cell_family_type<I>, D> & boundary_mesh, const cell_family_type<J> & cell) const
+            -> void
         requires(I == J)
         {
             // add {subcell} to the boundary mesh
@@ -70,7 +71,8 @@ namespace mito::mesh {
 
         template <int I, int J>
         inline auto _insert_subcells(
-            Mesh<cell_family_t<I>, D> & boundary_mesh, const cell_family_t<J> & cell) const -> void
+            Mesh<cell_family_type<I>, D> & boundary_mesh, const cell_family_type<J> & cell) const
+            -> void
         requires(I < J)
         {
             // loop on the subcells of {cell}
@@ -108,7 +110,7 @@ namespace mito::mesh {
             return std::size(_cells);
         }
 
-        inline auto cells() const noexcept -> const cells_t &
+        inline auto cells() const noexcept -> const cells_type &
         {
             // all done
             return _cells;
@@ -136,7 +138,7 @@ namespace mito::mesh {
             return;
         }
 
-        inline auto isOnBoundary(const cell_family_t<N - 1> & cell) const -> bool
+        inline auto isOnBoundary(const cell_family_type<N - 1> & cell) const -> bool
         {
             // count how many times this oriented cell occurs in the mesh with opposite orientation
             int count = 0;
@@ -183,11 +185,11 @@ namespace mito::mesh {
          * @brief Returns a mesh with all boundary cells of dimension I
          */
         template <int I = N - 1>
-        inline auto boundary() const -> Mesh<cell_family_t<I>, D> const
+        inline auto boundary() const -> Mesh<cell_family_type<I>, D> const
         requires(I >= 0)
         {
             // instantiate a new mesh for the boundary elements
-            Mesh<cell_family_t<I>, D> boundary_mesh(_geometry);
+            Mesh<cell_family_type<I>, D> boundary_mesh(_geometry);
 
             // loop on the (N-1)-dimensional cells
             for (const auto & cell : cells()) {
@@ -237,17 +239,17 @@ namespace mito::mesh {
 
       public:
         // const accessor to geometry
-        auto geometry() const noexcept -> const geometry_t & { return _geometry; }
+        auto geometry() const noexcept -> const geometry_type & { return _geometry; }
 
       private:
         // a reference to the geometry where the cells are embedded
-        const geometry_t & _geometry;
+        const geometry_type & _geometry;
 
         // container to store the mesh cells
-        cells_t _cells;
+        cells_type _cells;
 
         // container to store how many times a simplex appears with a given orientation
-        orientation_map_t _orientations;
+        orientation_map_type _orientations;
     };
 
 }    // namespace mito

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -10,9 +10,9 @@ namespace mito::mesh {
 
       public:
         // publish the order of the cell
-        static constexpr int order = cellT::resource_type::order;
+        static constexpr int order = topology::order<cellT>();
         // publish the number of vertices per element
-        static constexpr int n_vertices = cellT::resource_type::n_vertices;
+        static constexpr int n_vertices = topology::n_vertices<cellT>();
         // publish the dimension of physical space
         static constexpr int dim = D;
         // typedef for cell type
@@ -20,10 +20,10 @@ namespace mito::mesh {
 
       private:
         // get the order of the cell
-        static constexpr int N = cellT::resource_type::order;
+        static constexpr int N = order;
         // get the family this cell type belongs to (e.g. simplicial cells)
         template <int I>
-        using cell_family_t = typename cellT::resource_type::template cell_family_t<I>;
+        using cell_family_t = typename topology::cell_family<cellT, I>;
         // typedef for geometry type
         using geometry_t = geometry::geometry_t<D>;
         // typedef for a collection of cells

--- a/lib/mito/mesh/metis/Partitioner.icc
+++ b/lib/mito/mesh/metis/Partitioner.icc
@@ -43,8 +43,8 @@ mito::mesh::metis::Partitioner<meshT>::_get_ordered_mesh_cells(const mesh_t & me
 
     // define operator< for cells, given a geometry
     auto cell_compare = [&geometry](
-                            const typename mesh_t::cell_t & cell_a,
-                            const typename mesh_t::cell_t & cell_b) -> bool {
+                            const typename mesh_t::cell_type & cell_a,
+                            const typename mesh_t::cell_type & cell_b) -> bool {
         // get the barycenter of {cell_a}
         auto barycenter_a = mito::geometry::barycenter(cell_a, geometry);
         // get the barycenter of {cell_a}
@@ -54,7 +54,7 @@ mito::mesh::metis::Partitioner<meshT>::_get_ordered_mesh_cells(const mesh_t & me
     };
 
     // an ordered set of cells
-    std::set<typename mesh_t::cell_t, decltype(cell_compare)> cells(cell_compare);
+    std::set<typename mesh_t::cell_type, decltype(cell_compare)> cells(cell_compare);
 
     // insert mesh cells in ordered set
     for (const auto & cell : mesh.cells()) {

--- a/lib/mito/mesh/tetra.h
+++ b/lib/mito/mesh/tetra.h
@@ -222,7 +222,7 @@ namespace mito::mesh {
 
             // helper function to expand array to parameter pack
             constexpr auto _subdivide = []<size_t... J>(
-                const topology::vertex_simplex_composition_t<cellT::resource_type::order> & vertices,
+                const topology::vertex_simplex_composition_t<topology::order<cellT>()> & vertices,
                 geometry::geometry_t<D> & geometry, mesh_t<cellT, D> & subdivided_mesh,
                 int n_refinements, std::index_sequence<J...>)
             {
@@ -232,7 +232,7 @@ namespace mito::mesh {
             // recursively subdivide the cell identified by these vertices
             _subdivide(
                 vertices, geometry, subdivided_mesh, n_refinements,
-                std::make_index_sequence<cellT::resource_type::order + 1> {});
+                std::make_index_sequence<topology::order<cellT>() + 1> {});
         }
 
         // return the refined mesh

--- a/lib/mito/mesh/tetra.h
+++ b/lib/mito/mesh/tetra.h
@@ -12,7 +12,7 @@ namespace mito::mesh {
     requires(std::is_same_v<cellT, topology::segment_t>)
     {
         // compute the middle point of the segment 0->1
-        auto & vertex_01 = geometry.node(
+        auto vertex_01 = geometry.node(
             0.5
             * (geometry.point(vertex_0)->coordinates() + geometry.point(vertex_1)->coordinates()));
 
@@ -20,8 +20,8 @@ namespace mito::mesh {
         if (n_refinements == 1) {
 
             // instantiate new cells
-            auto & new_cell_0 = geometry.topology().segment({ vertex_0, vertex_01 });
-            auto & new_cell_1 = geometry.topology().segment({ vertex_01, vertex_1 });
+            auto new_cell_0 = geometry.topology().segment({ vertex_0, vertex_01 });
+            auto new_cell_1 = geometry.topology().segment({ vertex_01, vertex_1 });
 
             // insert new cells in new mesh
             subdivided_mesh.insert(new_cell_0);
@@ -47,17 +47,17 @@ namespace mito::mesh {
     requires(std::is_same_v<cellT, topology::triangle_t>)
     {
         // compute the middle point of the segment 0->1
-        auto & vertex_01 = geometry.node(
+        auto vertex_01 = geometry.node(
             0.5
             * (geometry.point(vertex_0)->coordinates() + geometry.point(vertex_1)->coordinates()));
 
         // compute the middle point of the segment 1->2
-        auto & vertex_12 = geometry.node(
+        auto vertex_12 = geometry.node(
             0.5
             * (geometry.point(vertex_1)->coordinates() + geometry.point(vertex_2)->coordinates()));
 
         // compute the middle point of the segment 2->0
-        auto & vertex_20 = geometry.node(
+        auto vertex_20 = geometry.node(
             0.5
             * (geometry.point(vertex_2)->coordinates() + geometry.point(vertex_0)->coordinates()));
 
@@ -65,10 +65,10 @@ namespace mito::mesh {
         if (n_refinements == 1) {
 
             // instantiate new cells
-            auto & new_cell_0 = geometry.topology().triangle({ vertex_0, vertex_01, vertex_20 });
-            auto & new_cell_1 = geometry.topology().triangle({ vertex_01, vertex_1, vertex_12 });
-            auto & new_cell_2 = geometry.topology().triangle({ vertex_12, vertex_2, vertex_20 });
-            auto & new_cell_3 = geometry.topology().triangle({ vertex_20, vertex_01, vertex_12 });
+            auto new_cell_0 = geometry.topology().triangle({ vertex_0, vertex_01, vertex_20 });
+            auto new_cell_1 = geometry.topology().triangle({ vertex_01, vertex_1, vertex_12 });
+            auto new_cell_2 = geometry.topology().triangle({ vertex_12, vertex_2, vertex_20 });
+            auto new_cell_3 = geometry.topology().triangle({ vertex_20, vertex_01, vertex_12 });
 
             // insert new cells in new mesh
             subdivided_mesh.insert(new_cell_0);
@@ -98,32 +98,32 @@ namespace mito::mesh {
     requires(std::is_same_v<cellT, topology::tetrahedron_t>)
     {
         // compute the middle point of the segment 0->1
-        auto & vertex_01 = geometry.node(
+        auto vertex_01 = geometry.node(
             0.5
             * (geometry.point(vertex_0)->coordinates() + geometry.point(vertex_1)->coordinates()));
 
         // compute the middle point of the segment 0->2
-        auto & vertex_02 = geometry.node(
+        auto vertex_02 = geometry.node(
             0.5
             * (geometry.point(vertex_0)->coordinates() + geometry.point(vertex_2)->coordinates()));
 
         // compute the middle point of the segment 0->3
-        auto & vertex_03 = geometry.node(
+        auto vertex_03 = geometry.node(
             0.5
             * (geometry.point(vertex_0)->coordinates() + geometry.point(vertex_3)->coordinates()));
 
         // compute the middle point of the segment 1->2
-        auto & vertex_12 = geometry.node(
+        auto vertex_12 = geometry.node(
             0.5
             * (geometry.point(vertex_1)->coordinates() + geometry.point(vertex_2)->coordinates()));
 
         // compute the middle point of the segment 1->3
-        auto & vertex_13 = geometry.node(
+        auto vertex_13 = geometry.node(
             0.5
             * (geometry.point(vertex_1)->coordinates() + geometry.point(vertex_3)->coordinates()));
 
         // compute the middle point of the segment 2->3
-        auto & vertex_23 = geometry.node(
+        auto vertex_23 = geometry.node(
             0.5
             * (geometry.point(vertex_2)->coordinates() + geometry.point(vertex_3)->coordinates()));
 
@@ -131,21 +131,21 @@ namespace mito::mesh {
         if (n_refinements == 1) {
 
             // instantiate new cells
-            auto & new_cell_0 =
+            auto new_cell_0 =
                 geometry.topology().tetrahedron({ vertex_0, vertex_01, vertex_02, vertex_03 });
-            auto & new_cell_1 =
+            auto new_cell_1 =
                 geometry.topology().tetrahedron({ vertex_1, vertex_01, vertex_13, vertex_12 });
-            auto & new_cell_2 =
+            auto new_cell_2 =
                 geometry.topology().tetrahedron({ vertex_2, vertex_12, vertex_02, vertex_23 });
-            auto & new_cell_3 =
+            auto new_cell_3 =
                 geometry.topology().tetrahedron({ vertex_3, vertex_03, vertex_13, vertex_23 });
-            auto & new_cell_4 =
+            auto new_cell_4 =
                 geometry.topology().tetrahedron({ vertex_02, vertex_01, vertex_13, vertex_03 });
-            auto & new_cell_5 =
+            auto new_cell_5 =
                 geometry.topology().tetrahedron({ vertex_02, vertex_03, vertex_13, vertex_23 });
-            auto & new_cell_6 =
+            auto new_cell_6 =
                 geometry.topology().tetrahedron({ vertex_02, vertex_01, vertex_13, vertex_12 });
-            auto & new_cell_7 =
+            auto new_cell_7 =
                 geometry.topology().tetrahedron({ vertex_02, vertex_23, vertex_13, vertex_12 });
 
             // insert new cells in new mesh

--- a/lib/mito/mesh/tetra.h
+++ b/lib/mito/mesh/tetra.h
@@ -222,7 +222,7 @@ namespace mito::mesh {
 
             // helper function to expand array to parameter pack
             constexpr auto _subdivide = []<size_t... J>(
-                const topology::vertex_simplex_composition_t<cellT::resource_t::order> & vertices,
+                const topology::vertex_simplex_composition_t<cellT::resource_type::order> & vertices,
                 geometry::geometry_t<D> & geometry, mesh_t<cellT, D> & subdivided_mesh,
                 int n_refinements, std::index_sequence<J...>)
             {
@@ -232,7 +232,7 @@ namespace mito::mesh {
             // recursively subdivide the cell identified by these vertices
             _subdivide(
                 vertices, geometry, subdivided_mesh, n_refinements,
-                std::make_index_sequence<cellT::resource_t::order + 1> {});
+                std::make_index_sequence<cellT::resource_type::order + 1> {});
         }
 
         // return the refined mesh

--- a/lib/mito/topology/OrientedSimplex.h
+++ b/lib/mito/topology/OrientedSimplex.h
@@ -117,6 +117,7 @@ namespace mito::topology {
             return _footprint->edges(edges);
         }
 
+        // TOFIX: remove methods sanity check, a simplex does not need it
         // returns whether the simplex passes the sanity check
         inline auto sanityCheck() const -> bool { return _footprint->sanityCheck(); }
 
@@ -125,8 +126,8 @@ namespace mito::topology {
         const unoriented_simplex_t<D> _footprint;
         // the orientation
         const bool _orientation;
-        // private friendship with the factory of oriented simplices
-        friend class OrientedSimplexFactory<D>;
+        // private friendship with the repository of oriented simplices
+        friend class utilities::Repository<OrientedSimplex<D>>;
     };
 }
 #endif    // mito_topology_OrientedSimplex_h

--- a/lib/mito/topology/OrientedSimplex.h
+++ b/lib/mito/topology/OrientedSimplex.h
@@ -3,7 +3,7 @@
 #define mito_topology_OrientedSimplex_h
 
 /*
- * This class represents an OrientedSimplex of order D.
+ * This class represents an OrientedSimplex of order N.
  *
  * Each instance of OrientedSimplex consists of an underlying Simplex (the footprint) and an
  * orientation, which can be either zero or one. When the orientation is one, the OrientedSimplex
@@ -17,24 +17,24 @@
 
 namespace mito::topology {
 
-    template <int D>
+    template <int N>
     class OrientedSimplex : public utilities::Shareable {
       public:
         // order of simplex
-        static constexpr int order = D;
+        static constexpr int order = N;
 
         // number of vertices of simplex
         static constexpr int n_vertices = order + 1;
 
         // typedef for the cell family type (simplicial)
-        template <int N>
-        using cell_family_t = simplex_t<N>;
+        template <int I>
+        using cell_family_t = simplex_t<I>;
 
         // private constructors: only the OrientedSimplexFactory has the right to instantiate
         // oriented simplices
       private:
         // constructor with an existing shared pointer as footprint
-        constexpr OrientedSimplex(const unoriented_simplex_t<D> & footprint, bool orientation) :
+        constexpr OrientedSimplex(const unoriented_simplex_t<N> & footprint, bool orientation) :
             _footprint(footprint),
             _orientation(orientation)
         {}
@@ -60,7 +60,7 @@ namespace mito::topology {
 
       public:
         // accessor for the unoriented footprint
-        inline auto footprint() const noexcept -> const unoriented_simplex_t<D> &
+        inline auto footprint() const noexcept -> const unoriented_simplex_t<N> &
         {
             return _footprint;
         }
@@ -71,7 +71,7 @@ namespace mito::topology {
         inline auto orientation() const noexcept -> bool { return _orientation; }
 
         // returns the array of subsimplices
-        inline auto composition() const noexcept -> const simplex_composition_t<D> &
+        inline auto composition() const noexcept -> const simplex_composition_t<N> &
         {
             return _footprint->composition();
         }
@@ -84,8 +84,8 @@ namespace mito::topology {
         }
 
         // return the array of vertices of this simplex
-        inline auto vertices() const -> vertex_simplex_composition_t<D>
-        requires(D > 0)
+        inline auto vertices() const -> vertex_simplex_composition_t<N>
+        requires(N > 0)
         {
             // a set of vertices
             vertex_set_t vertices_collection;
@@ -93,8 +93,8 @@ namespace mito::topology {
             // fetch the vertices of this simplex
             _footprint->vertices(vertices_collection);
 
-            // an array to store the composition of a D-simplex in terms of vertices
-            vertex_simplex_composition_t<D> vertices;
+            // an array to store the composition of a N-simplex in terms of vertices
+            vertex_simplex_composition_t<N> vertices;
 
             // assert that you found the correct number of vertices
             assert(std::size(vertices_collection) == std::size(vertices));
@@ -123,11 +123,11 @@ namespace mito::topology {
 
       private:
         // the shared pointer to the footprint
-        const unoriented_simplex_t<D> _footprint;
+        const unoriented_simplex_t<N> _footprint;
         // the orientation
         const bool _orientation;
         // private friendship with the repository of oriented simplices
-        friend class utilities::Repository<oriented_simplex_t<D>>;
+        friend class utilities::Repository<oriented_simplex_t<N>>;
     };
 }
 #endif    // mito_topology_OrientedSimplex_h

--- a/lib/mito/topology/OrientedSimplex.h
+++ b/lib/mito/topology/OrientedSimplex.h
@@ -39,7 +39,6 @@ namespace mito::topology {
             _orientation(orientation)
         {}
 
-      public:
         // destructor
         constexpr ~OrientedSimplex() override {}
 
@@ -122,18 +121,8 @@ namespace mito::topology {
         inline auto sanityCheck() const -> bool { return _footprint->sanityCheck(); }
 
       private:
-        inline auto _erase() -> void
-        {
-            // reset the footprint shared pointer
-            _footprint.reset();
-
-            // all done
-            return;
-        }
-
-      private:
         // the shared pointer to the footprint
-        unoriented_simplex_t<D> _footprint;    // TOFIX: should this be {const}?
+        const unoriented_simplex_t<D> _footprint;
         // the orientation
         const bool _orientation;
         // private friendship with the factory of oriented simplices

--- a/lib/mito/topology/OrientedSimplex.h
+++ b/lib/mito/topology/OrientedSimplex.h
@@ -127,7 +127,7 @@ namespace mito::topology {
         // the orientation
         const bool _orientation;
         // private friendship with the repository of oriented simplices
-        friend class utilities::Repository<OrientedSimplex<D>>;
+        friend class utilities::Repository<oriented_simplex_t<D>>;
     };
 }
 #endif    // mito_topology_OrientedSimplex_h

--- a/lib/mito/topology/OrientedSimplex.h
+++ b/lib/mito/topology/OrientedSimplex.h
@@ -28,7 +28,7 @@ namespace mito::topology {
 
         // typedef for the cell family type (simplicial)
         template <int I>
-        using cell_family_t = simplex_t<I>;
+        using cell_family_type = simplex_t<I>;
 
         // private constructors: only the OrientedSimplexFactory has the right to instantiate
         // oriented simplices

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -21,8 +21,7 @@ namespace mito::topology {
     class OrientedSimplexFactory {
       private:
         // typedef for a repository of oriented simplices
-        using oriented_simplex_repository_t =
-            utilities::repository_t<typename simplex_t<D>::resource_t>;
+        using oriented_simplex_repository_t = utilities::repository_t<simplex_t<D>>;
 
         // id type of unoriented simplex
         using unoriented_simplex_id_t = utilities::index_t<unoriented_simplex_t<D>>;

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -182,8 +182,11 @@ namespace mito::topology {
         // only if there is no one else using it, otherwise does nothing)
         inline auto erase(simplex_t<N> & oriented_simplex) -> void
         {
-            // sanity check
-            assert(oriented_simplex.references() > 0);
+            // if this oriented simplex is still being used
+            if (oriented_simplex.references() > 1) {
+                // do nothing
+                return;
+            }
 
             // grab a copy of the footprint
             auto footprint = oriented_simplex->footprint();

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -208,6 +208,9 @@ namespace mito::topology {
             // erase this oriented simplex from the oriented simplex factory
             _orientations.erase(mytuple);
 
+            // erase this oriented simplex from the container
+            _oriented_simplices.erase(oriented_simplex);
+
             // if this simplex is the last one using the footprint (other than the copy we just
             // did)
             if (footprint.references() == 2) {

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -200,9 +200,8 @@ namespace mito::topology {
             // erase this oriented simplex from the container
             _oriented_simplices.erase(oriented_simplex);
 
-            // if this simplex is the last one using the footprint (other than the copy we just
-            // did)
-            if (footprint.references() == 2) {
+            // if the copy I just made is the only remaining use the footprint
+            if (footprint.references() == 1) {
                 // cleanup the unoriented factory around {footprint}
                 _simplex_factory.erase(footprint);
             }

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -203,11 +203,8 @@ namespace mito::topology {
             // erase this oriented simplex from the container
             _oriented_simplices.erase(oriented_simplex);
 
-            // if the copy I just made is the only remaining use the footprint
-            if (footprint.references() == 1) {
-                // cleanup the unoriented factory around {footprint}
-                _simplex_factory.erase(footprint);
-            }
+            // cleanup the unoriented factory around {footprint}
+            _simplex_factory.erase(footprint);
 
             // all done
             return;

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -24,10 +24,15 @@ namespace mito::topology {
         using oriented_simplex_repository_t =
             utilities::repository_t<typename simplex_t<D>::resource_t>;
 
+        // id type of unoriented simplex
+        using unoriented_simplex_id_t = utilities::index_t<unoriented_simplex_t<D>>;
+
+        // id type of oriented simplex
+        using simplex_id_t = utilities::index_t<simplex_t<D>>;
+
         // typedef for an orientation map of simplices:
         // this map maps a simplex pointer and a boolean to an oriented simplex pointer
-        using orientation_map_t =
-            std::map<std::tuple<unoriented_simplex_id_t<D>, bool>, simplex_id_t<D>>;
+        using orientation_map_t = std::map<std::tuple<unoriented_simplex_id_t, bool>, simplex_id_t>;
 
       private:
         // default constructor
@@ -185,7 +190,7 @@ namespace mito::topology {
             auto footprint = oriented_simplex->footprint();
 
             // get footprint of the oriented simplex
-            unoriented_simplex_id_t<D> id = oriented_simplex->footprint().id();
+            unoriented_simplex_id_t id = oriented_simplex->footprint().id();
 
             // get the key to this oriented simplex
             auto mytuple = std::make_tuple(id, oriented_simplex->orientation());
@@ -214,6 +219,8 @@ namespace mito::topology {
             const simplex_composition_t<D> & composition,
             const unoriented_simplex_t<D> & simplex) const;
 
+        inline auto _rotate(const simplex_composition_t<D> & composition) const;
+
       private:
         // factory for simplices
         simplex_factory_t<D> _simplex_factory;
@@ -239,23 +246,22 @@ namespace mito::topology {
         return false;
     }
 
-    namespace {
-        inline auto _rotate(const simplex_composition_t<2> & composition)
-        {
-            // an array of oriented simplices ids
-            using oriented_simplex_array_t = std::array<oriented_simplex_id_t<2>, 3>;
+    template <>
+    inline auto OrientedSimplexFactory<2>::_rotate(
+        const simplex_composition_t<2> & composition) const
+    {
+        // an array of oriented simplices ids
+        using oriented_simplex_array_t = std::array<simplex_id_t, 3>;
 
-            // get the oriented simplices from the shared pointers
-            auto composition_copy =
-                oriented_simplex_array_t { composition[0].id(), composition[1].id(),
-                                           composition[2].id() };
-            auto first_simplex =
-                std::min_element(std::begin(composition_copy), std::end(composition_copy));
-            std::rotate(std::begin(composition_copy), first_simplex, std::end(composition_copy));
+        // get the oriented simplices from the shared pointers
+        auto composition_copy = oriented_simplex_array_t { composition[0].id(), composition[1].id(),
+                                                           composition[2].id() };
+        auto first_simplex =
+            std::min_element(std::begin(composition_copy), std::end(composition_copy));
+        std::rotate(std::begin(composition_copy), first_simplex, std::end(composition_copy));
 
-            // return rotated composition
-            return composition_copy;
-        }
+        // return rotated composition
+        return composition_copy;
     }
 
     // compute the orientation of the {composition} with respect to the orientation of {simplex}

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -6,28 +6,28 @@ namespace mito::topology {
 
     /**
      *
-     * This class represents a factory for oriented simplices of order D.
+     * This class represents a factory for oriented simplices of order N.
      *
-     * The factory class is aware of the class of equivalence for an OrientedSimplex of order D. In
-     * fact, being an instance of OrientedSimplex<D> identified by its D+1 subsimplices (through its
-     * footprint), there are (D+1)!/2 possible representations of the same oriented simplex. The
+     * The factory class is aware of the class of equivalence for an OrientedSimplex of order N. In
+     * fact, being an instance of OrientedSimplex<N> identified by its N+1 subsimplices (through its
+     * footprint), there are (N+1)!/2 possible representations of the same oriented simplex. The
      * factory makes sure that at any given time there is at most one OrientedSimplex for an
      * equivalence class, i.e. the representative of the class. The representative of the class of
      * equivalence is chosen by starting the composition with the subsimplex of smallest address and
      * by circularly rotating the other simplices in the composition array around the first simplex.
      */
 
-    template <int D>
+    template <int N>
     class OrientedSimplexFactory {
       private:
         // typedef for a repository of oriented simplices
-        using oriented_simplex_repository_t = utilities::repository_t<simplex_t<D>>;
+        using oriented_simplex_repository_t = utilities::repository_t<simplex_t<N>>;
 
         // id type of unoriented simplex
-        using unoriented_simplex_id_t = utilities::index_t<unoriented_simplex_t<D>>;
+        using unoriented_simplex_id_t = utilities::index_t<unoriented_simplex_t<N>>;
 
         // id type of oriented simplex
-        using simplex_id_t = utilities::index_t<simplex_t<D>>;
+        using simplex_id_t = utilities::index_t<simplex_t<N>>;
 
         // typedef for an orientation map of simplices:
         // this map maps a simplex pointer and a boolean to an oriented simplex pointer
@@ -44,7 +44,7 @@ namespace mito::topology {
         ~OrientedSimplexFactory() {}
 
       private:
-        inline auto existsOrientedSimplex(const simplex_composition_t<D> & composition) const
+        inline auto existsOrientedSimplex(const simplex_composition_t<N> & composition) const
             -> bool
         {
             // find the representative of simplices with composition {composition} from the
@@ -68,7 +68,7 @@ namespace mito::topology {
         }
 
         inline auto existsOrientedSimplex(
-            const unoriented_simplex_t<D> & simplex, bool orientation) const -> bool
+            const unoriented_simplex_t<N> & simplex, bool orientation) const -> bool
         {
             // find oriented simplex with the given footprint and orientation
             auto orientedSimplex = findOrientedSimplex(simplex, orientation);
@@ -79,7 +79,7 @@ namespace mito::topology {
         }
 
         inline auto findOrientedSimplex(
-            const unoriented_simplex_t<D> & simplex, bool orientation) const -> simplex_t<D>
+            const unoriented_simplex_t<N> & simplex, bool orientation) const -> simplex_t<N>
         {
             // bind the footprint and the orientation in a tuple
             auto tuple = std::make_tuple(simplex.id(), orientation);
@@ -96,7 +96,7 @@ namespace mito::topology {
             // if not found
             else {
                 // return a shared pointer wrapper around {nullptr}
-                return simplex_t<D>();
+                return simplex_t<N>();
             }
         }
 
@@ -104,8 +104,8 @@ namespace mito::topology {
         // {orientation} (either create a new oriented simplex if such oriented simplex does not
         // exist in the factory or return the existing representative of the class of
         // equivalence of oriented simplices with footprint {simplex} orientation {orientation}
-        inline auto orientedSimplex(const unoriented_simplex_t<D> & simplex, bool orientation)
-            -> simplex_t<D>
+        inline auto orientedSimplex(const unoriented_simplex_t<N> & simplex, bool orientation)
+            -> simplex_t<N>
         {
             // bind the footprint and the orientation in a tuple
             auto tuple = std::make_tuple(simplex.id(), orientation);
@@ -136,8 +136,8 @@ namespace mito::topology {
         // return a simplex with composition {composition} (either create a new simplex if such
         // simplex does not exist in the factory or return the existing representative of the
         // class of equivalence of simplices with this composition)
-        inline auto orientedSimplex(const simplex_composition_t<D> & composition) -> simplex_t<D>
-        requires(D > 0)
+        inline auto orientedSimplex(const simplex_composition_t<N> & composition) -> simplex_t<N>
+        requires(N > 0)
         {
             if (!isValid(composition)) {
                 pyre::journal::firewall_t firewall("topology::OrientedSimplexFactory");
@@ -160,7 +160,7 @@ namespace mito::topology {
         }
 
         inline auto orientedSimplex(bool orientation) -> simplex_t<0>
-        requires(D == 0)
+        requires(N == 0)
         {
             // get the representative of simplices with composition {composition} from the
             // factory
@@ -172,7 +172,7 @@ namespace mito::topology {
 
         // instantiate a vertex
         inline auto vertex() -> vertex_t
-        requires(D == 0)
+        requires(N == 0)
         {
             // ask the factory of unoriented vertices for an unoriented vertex
             return _simplex_factory.simplex();
@@ -180,7 +180,7 @@ namespace mito::topology {
 
         // erase an oriented simplex from the factory (this method actually erases the simplex
         // only if there is no one else using it, otherwise does nothing)
-        inline auto erase(simplex_t<D> & oriented_simplex) -> void
+        inline auto erase(simplex_t<N> & oriented_simplex) -> void
         {
             // sanity check
             assert(oriented_simplex.references() > 0);
@@ -215,14 +215,14 @@ namespace mito::topology {
         // compute the orientation of the {composition} with respect to the orientation of
         // {simplex}
         inline bool _orientation(
-            const simplex_composition_t<D> & composition,
-            const unoriented_simplex_t<D> & simplex) const;
+            const simplex_composition_t<N> & composition,
+            const unoriented_simplex_t<N> & simplex) const;
 
-        inline auto _rotate(const simplex_composition_t<D> & composition) const;
+        inline auto _rotate(const simplex_composition_t<N> & composition) const;
 
       private:
         // factory for simplices
-        simplex_factory_t<D> _simplex_factory;
+        simplex_factory_t<N> _simplex_factory;
 
         // container to store the oriented simplices
         oriented_simplex_repository_t _oriented_simplices;

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -239,7 +239,7 @@ namespace mito::topology {
             OrientedSimplex<D> * resource = new (location) OrientedSimplex<D>(simplex, orientation);
 
             // wrap the new simplex in a shared pointer and return it
-            return utilities::shared_ptr<OrientedSimplex<D>>(resource, &_oriented_simplices);
+            return utilities::shared_ptr<OrientedSimplex<D>>(resource);
         }
 
       private:

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -202,8 +202,8 @@ namespace mito::topology {
             // get the key to this oriented simplex
             auto mytuple = std::make_tuple(id, oriented_simplex->orientation());
 
-            // erase the simplex
-            oriented_simplex->_erase();
+            // destroy the simplex
+            oriented_simplex->~OrientedSimplex<D>();
 
             // erase this oriented simplex from the oriented simplex factory
             _orientations.erase(mytuple);

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -166,13 +166,6 @@ namespace mito::topology {
             return orientedSimplex(simplex, orientation);
         }
 
-        // get the oriented simplex corresponding to the id {simplex_id}
-        inline auto orientedSimplex(oriented_simplex_id_t<D> simplex_id) -> simplex_t<D>
-        {
-            // ask the simplices container for the resource corresponding to this id
-            return _oriented_simplices.resource(simplex_id);
-        }
-
         // instantiate a vertex
         inline auto vertex() -> vertex_t
         requires(D == 0)

--- a/lib/mito/topology/OrientedSimplexFactory.h
+++ b/lib/mito/topology/OrientedSimplexFactory.h
@@ -28,7 +28,7 @@ namespace mito::topology {
         using orientation_map_t =
             std::map<std::tuple<unoriented_simplex_id_t<D>, bool>, simplex_t<D>>;
 
-      public:    // TOFIX: should be private but the default constructor of tuple needs it public
+      private:
         // default constructor
         OrientedSimplexFactory() :
             _simplex_factory(),

--- a/lib/mito/topology/Simplex.h
+++ b/lib/mito/topology/Simplex.h
@@ -127,8 +127,8 @@ namespace mito::topology {
         // the simplex composition in terms of subsimplices
         const simplex_composition_t<D> _simplices;
 
-        // private friendship with the factory of simplices
-        friend class SimplexFactory<D>;
+        // private friendship with the repository of simplices
+        friend class utilities::Repository<Simplex<D>>;
     };
 
     /*
@@ -168,15 +168,8 @@ namespace mito::topology {
         }
 
       private:
-        inline auto _erase() -> void
-        {
-            // all done
-            return;
-        }
-
-      private:
-        // friendship with the factory of simplices
-        friend class SimplexFactory<0>;
+        // friendship with the repository of simplices
+        friend class utilities::Repository<Simplex<0>>;
     };
 
 }    // namespace mito

--- a/lib/mito/topology/Simplex.h
+++ b/lib/mito/topology/Simplex.h
@@ -22,7 +22,6 @@ namespace mito::topology {
         // constructor for a simplex based on its composition in terms of subsimplices
         constexpr Simplex(simplex_composition_t<D> && simplices) : _simplices(simplices) {}
 
-      public:
         // destructor
         constexpr ~Simplex() override {}
 
@@ -125,20 +124,8 @@ namespace mito::topology {
         }
 
       private:
-        inline auto _erase() -> void
-        {
-            // reset the subsimplices shared pointers
-            for (auto & simplex : _simplices) {
-                simplex.reset();
-            }
-
-            // all done
-            return;
-        }
-
-      private:
         // the simplex composition in terms of subsimplices
-        simplex_composition_t<D> _simplices;    // TOFIX: should this be {const}?
+        const simplex_composition_t<D> _simplices;
 
         // private friendship with the factory of simplices
         friend class SimplexFactory<D>;
@@ -156,7 +143,6 @@ namespace mito::topology {
         // default constructor
         constexpr Simplex() {}
 
-      public:
         // empty destructor
         constexpr ~Simplex() override {}
 

--- a/lib/mito/topology/Simplex.h
+++ b/lib/mito/topology/Simplex.h
@@ -5,22 +5,22 @@
 namespace mito::topology {
 
     /*
-     * This class represents a Simplex of order D > 0.
+     * This class represents a Simplex of order N > 0.
      *
-     * Simplex<D> is represented recursively as a collection of D+1 subsimplices of type
-     * Simplex<D-1>.
+     * Simplex<N> is represented recursively as a collection of N+1 subsimplices of type
+     * Simplex<N-1>.
      */
 
-    template <int D>
+    template <int N>
     class Simplex : public utilities::Shareable {
 
         // private constructors: only the SimplexFactory has the right to instantiate simplices
       private:
         // constructor for a simplex based on its composition in terms of subsimplices
-        constexpr Simplex(const simplex_composition_t<D> & simplices) : _simplices(simplices) {}
+        constexpr Simplex(const simplex_composition_t<N> & simplices) : _simplices(simplices) {}
 
         // constructor for a simplex based on its composition in terms of subsimplices
-        constexpr Simplex(simplex_composition_t<D> && simplices) : _simplices(simplices) {}
+        constexpr Simplex(simplex_composition_t<N> && simplices) : _simplices(simplices) {}
 
         // destructor
         constexpr ~Simplex() override {}
@@ -43,7 +43,7 @@ namespace mito::topology {
 
       public:
         // accessor for the subsimplices
-        inline auto composition() const noexcept -> const simplex_composition_t<D> &
+        inline auto composition() const noexcept -> const simplex_composition_t<N> &
         {
             return _simplices;
         }
@@ -51,7 +51,7 @@ namespace mito::topology {
         // append the vertices of this simplex to a collection of vertices
         template <class VERTEX_COLLECTION_T>
         void vertices(VERTEX_COLLECTION_T & vertices) const
-        requires(D > 1)
+        requires(N > 1)
         {
             for (const auto & simplex : composition()) {
                 simplex->vertices(vertices);
@@ -61,7 +61,7 @@ namespace mito::topology {
         // append the vertices of this simplex to a collection of vertices
         template <class VERTEX_COLLECTION_T>
         void vertices(VERTEX_COLLECTION_T & vertices) const
-        requires(D == 1)
+        requires(N == 1)
         {
             vertices.insert(_simplices[0]->footprint());
             vertices.insert(_simplices[1]->footprint());
@@ -70,9 +70,9 @@ namespace mito::topology {
         // append the edges of this simplex to a collection of edges
         template <class EDGES_COLLECTION_T>
         inline auto edges(EDGES_COLLECTION_T & edges) const -> void
-        requires(D > 2)
+        requires(N > 2)
         {
-            // if D > 2, then recursively fetch the edges from the simplices in the composition
+            // if N > 2, then recursively fetch the edges from the simplices in the composition
             for (const auto & simplex : composition()) {
                 simplex->edges(edges);
             }
@@ -84,9 +84,9 @@ namespace mito::topology {
         // append the edges of this simplex to a collection of edges
         template <class EDGES_COLLECTION_T>
         inline auto edges(EDGES_COLLECTION_T & edges) const -> void
-        requires(D == 2)
+        requires(N == 2)
         {
-            // if D == 2, then this simplex is a triangle and its composition already consists of
+            // if N == 2, then this simplex is a triangle and its composition already consists of
             // edges
             for (const auto & edge : composition()) {
                 edges.insert(edge);
@@ -96,7 +96,7 @@ namespace mito::topology {
             return;
         }
 
-        // perform a sanity check (check that a simplex of order D has D+1 distinct vertices)
+        // perform a sanity check (check that a simplex of order N has N+1 distinct vertices)
         inline auto sanityCheck() const -> bool
         {
             // check the subsimplices
@@ -113,8 +113,8 @@ namespace mito::topology {
             // collect vertices of this simplex
             this->vertices(vertices);
 
-            // if this simplex does not have D+1 vertices, something went wrong
-            if (std::size(vertices) != int(D) + 1) {
+            // if this simplex does not have N+1 vertices, something went wrong
+            if (std::size(vertices) != int(N) + 1) {
                 // all done
                 return false;
             }
@@ -125,14 +125,14 @@ namespace mito::topology {
 
       private:
         // the simplex composition in terms of subsimplices
-        const simplex_composition_t<D> _simplices;
+        const simplex_composition_t<N> _simplices;
 
         // private friendship with the repository of simplices
-        friend class utilities::Repository<unoriented_simplex_t<D>>;
+        friend class utilities::Repository<unoriented_simplex_t<N>>;
     };
 
     /*
-     * This class collapses Simplex<D> for D = 0.
+     * This class collapses Simplex<N> for N = 0.
      *
      * A simplex of order 0, like a vertex, is an empty object.
      */

--- a/lib/mito/topology/Simplex.h
+++ b/lib/mito/topology/Simplex.h
@@ -128,7 +128,7 @@ namespace mito::topology {
         const simplex_composition_t<D> _simplices;
 
         // private friendship with the repository of simplices
-        friend class utilities::Repository<Simplex<D>>;
+        friend class utilities::Repository<unoriented_simplex_t<D>>;
     };
 
     /*
@@ -169,7 +169,7 @@ namespace mito::topology {
 
       private:
         // friendship with the repository of simplices
-        friend class utilities::Repository<Simplex<0>>;
+        friend class utilities::Repository<unoriented_simplex_t<0>>;
     };
 
 }    // namespace mito

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -22,10 +22,8 @@ namespace mito::topology {
     class SimplexFactory {
 
       private:
-        // TOFIX: how do we rename this to
         // typedef for a repository of unoriented simplices
-        using simplex_repository_t =
-            utilities::repository_t<typename unoriented_simplex_t<D>::resource_t>;
+        using simplex_repository_t = utilities::repository_t<unoriented_simplex_t<D>>;
 
         // id type of oriented simplex
         using unoriented_simplex_id_t = utilities::index_t<simplex_t<D>>;
@@ -191,7 +189,7 @@ namespace mito::topology {
 
       private:
         // typedef for a collection of unoriented simplices
-        using simplex_repository_t = utilities::repository_t<unoriented_simplex_t<0>::resource_t>;
+        using simplex_repository_t = utilities::repository_t<unoriented_simplex_t<0>>;
 
       private:
         // default constructor

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -139,7 +139,7 @@ namespace mito::topology {
             Simplex<D> * resource = new (location) Simplex<D>(composition);
 
             // wrap the new simplex in a shared pointer and return it
-            return utilities::shared_ptr<Simplex<D>>(resource, &_simplices);
+            return utilities::shared_ptr<Simplex<D>>(resource);
         }
 
       private:
@@ -262,7 +262,7 @@ namespace mito::topology {
             Simplex<0> * resource = new (location) Simplex<0>();
 
             // wrap the new simplex in a shared pointer and return it
-            return utilities::shared_ptr<Simplex<0>>(resource, &_simplices);
+            return utilities::shared_ptr<Simplex<0>>(resource);
         }
 
       private:

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -6,10 +6,10 @@ namespace mito::topology {
 
     /**
      *
-     * This class represents a factory for simplices of order D.
+     * This class represents a factory for simplices of order N.
      *
-     * The factory class is aware of the class of equivalence for a Simplex of order D. In fact,
-     * being an instance of Simplex<D> identified by its D+1 subsimplices, there are (D+1)! possible
+     * The factory class is aware of the class of equivalence for a Simplex of order N. In fact,
+     * being an instance of Simplex<N> identified by its N+1 subsimplices, there are (N+1)! possible
      * representations of the same simplex. The factory makes sure that at any given time
      * there is at most one simplex for an equivalence class, i.e. the representative of the class.
      * The representative of the class of equivalence is chosen by sorting in increasing order the
@@ -18,27 +18,27 @@ namespace mito::topology {
 
     // TOFIX: rename this to UnorientedSimplexFactory
 
-    template <int D>
+    template <int N>
     class SimplexFactory {
 
       private:
         // typedef for a repository of unoriented simplices
-        using simplex_repository_t = utilities::repository_t<unoriented_simplex_t<D>>;
+        using simplex_repository_t = utilities::repository_t<unoriented_simplex_t<N>>;
 
         // id type of oriented simplex
-        using unoriented_simplex_id_t = utilities::index_t<simplex_t<D>>;
+        using unoriented_simplex_id_t = utilities::index_t<simplex_t<N>>;
 
         // typedef for a composition map of simplices:
         // these maps map:
         //      2 pointers to nodes into a pointer to edge,
         //      3 pointers to edges into a pointer to face, ...
         // edges composition
-        // std::map<std::array<unoriented_simplex_id_t<D>, 2>, unoriented_simplex_t<1>>
+        // std::map<std::array<unoriented_simplex_id_t<N>, 2>, unoriented_simplex_t<1>>
         // faces compositions
-        // std::map<std::array<unoriented_simplex_id_t<D>, 3>, unoriented_simplex_t<2>>
+        // std::map<std::array<unoriented_simplex_id_t<N>, 3>, unoriented_simplex_t<2>>
         // volumes compositions
-        // std::map<std::array<unoriented_simplex_id_t<D>, 4>, unoriented_simplex_t<3>>
-        using composition_t = std::array<unoriented_simplex_id_t, D + 1>;
+        // std::map<std::array<unoriented_simplex_id_t<N>, 4>, unoriented_simplex_t<3>>
+        using composition_t = std::array<unoriented_simplex_id_t, N + 1>;
         using composition_map_t = std::map<composition_t, unoriented_simplex_id_t>;
 
       private:
@@ -48,8 +48,8 @@ namespace mito::topology {
         // destructor
         ~SimplexFactory() {}
 
-        inline auto findSimplex(const simplex_composition_t<D> & composition) const
-            -> unoriented_simplex_t<D>
+        inline auto findSimplex(const simplex_composition_t<N> & composition) const
+            -> unoriented_simplex_t<N>
         {
             // pick a representative (factor out equivalence relation)
             auto representative = _representative(composition);
@@ -65,14 +65,14 @@ namespace mito::topology {
             // if not found
             else {
                 // return a shared pointer wrapper around {nullptr}
-                return unoriented_simplex_t<D>();
+                return unoriented_simplex_t<N>();
             }
         }
 
         // return a simplex with composition {composition} (either create a new simplex if such
         // simplex does not exist in the factory or return the existing representative of the class
         // of equivalence of simplices with this composition)
-        inline auto simplex(const simplex_composition_t<D> & composition) -> unoriented_simplex_t<D>
+        inline auto simplex(const simplex_composition_t<N> & composition) -> unoriented_simplex_t<N>
         {
             // pick a representative (factor out equivalence relation)
             auto representative = _representative(composition);
@@ -101,7 +101,7 @@ namespace mito::topology {
 
         // erase a simplex from the factory (this method actually erases the simplex only if there
         // is no one else using it, otherwise does nothing)
-        inline auto erase(unoriented_simplex_t<D> & simplex) -> void
+        inline auto erase(unoriented_simplex_t<N> & simplex) -> void
         {
             // sanity check
             assert(simplex.references() > 0);
@@ -121,7 +121,7 @@ namespace mito::topology {
 
       private:
         // equivalence class relation for a simplex
-        inline auto _representative(const simplex_composition_t<D> & composition) const
+        inline auto _representative(const simplex_composition_t<N> & composition) const
             -> composition_t;
 
       private:
@@ -132,7 +132,7 @@ namespace mito::topology {
         composition_map_t _compositions;
 
         // private friendship with the factory of oriented simplices
-        friend class OrientedSimplexFactory<D>;
+        friend class OrientedSimplexFactory<N>;
     };
 
     // equivalence class relation for a simplex in 1D

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -117,6 +117,9 @@ namespace mito::topology {
             // erase this simplex from the compositions map
             _compositions.erase(representative);
 
+            // erase this simplex from the container
+            _simplices.erase(simplex);
+
             // all done
             return;
         }
@@ -241,6 +244,9 @@ namespace mito::topology {
 
             // erase the vertex from the vertex set
             _vertex_set.erase(simplex);
+
+            // erase this simplex from the container
+            _simplices.erase(simplex);
 
             // all done
             return;

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -27,6 +27,9 @@ namespace mito::topology {
         using simplex_repository_t =
             utilities::repository_t<typename unoriented_simplex_t<D>::resource_t>;
 
+        // id type of oriented simplex
+        using unoriented_simplex_id_t = utilities::index_t<simplex_t<D>>;
+
         // typedef for a composition map of simplices:
         // these maps map:
         //      2 pointers to nodes into a pointer to edge,
@@ -37,8 +40,8 @@ namespace mito::topology {
         // std::map<std::array<unoriented_simplex_id_t<D>, 3>, unoriented_simplex_t<2>>
         // volumes compositions
         // std::map<std::array<unoriented_simplex_id_t<D>, 4>, unoriented_simplex_t<3>>
-        using composition_t = std::array<unoriented_simplex_id_t<D>, D + 1>;
-        using composition_map_t = std::map<composition_t, unoriented_simplex_id_t<D>>;
+        using composition_t = std::array<unoriented_simplex_id_t, D + 1>;
+        using composition_map_t = std::map<composition_t, unoriented_simplex_id_t>;
 
       private:
         // default constructor

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -111,8 +111,8 @@ namespace mito::topology {
             // pick a representative (factor out equivalence relation)
             auto representative = _representative(simplex->composition());
 
-            // erase it
-            simplex->_erase();
+            // destroy the simplex
+            simplex->~Simplex<D>();
 
             // erase this simplex from the compositions map
             _compositions.erase(representative);
@@ -236,8 +236,8 @@ namespace mito::topology {
             // sanity check
             assert(simplex.references() > 0);
 
-            // erase the simplex
-            simplex->_erase();
+            // destroy the simplex
+            simplex->~Simplex<0>();
 
             // erase the vertex from the vertex set
             _vertex_set.erase(simplex);

--- a/lib/mito/topology/SimplexFactory.h
+++ b/lib/mito/topology/SimplexFactory.h
@@ -103,8 +103,11 @@ namespace mito::topology {
         // is no one else using it, otherwise does nothing)
         inline auto erase(unoriented_simplex_t<N> & simplex) -> void
         {
-            // sanity check
-            assert(simplex.references() > 0);
+            // if the simplex is still being used
+            if (simplex.references() > 1) {
+                // do nothing
+                return;
+            }
 
             // pick a representative (factor out equivalence relation)
             auto representative = _representative(simplex->composition());
@@ -211,8 +214,11 @@ namespace mito::topology {
         // is no one else using it, otherwise does nothing)
         inline auto erase(unoriented_simplex_t<0> & simplex) -> void
         {
-            // sanity check
-            assert(simplex.references() > 0);
+            // if the simplex is still being used
+            if (simplex.references() > 1) {
+                // do nothing
+                return;
+            }
 
             // erase this simplex from the container
             _simplices.erase(simplex);

--- a/lib/mito/topology/Topology.h
+++ b/lib/mito/topology/Topology.h
@@ -24,20 +24,20 @@ namespace mito::topology {
         ~Topology();
 
       public:
-        template <int D>
-        inline auto simplex(const unoriented_simplex_t<D> & footprint, bool orientation)
-            -> simplex_t<D>;
+        template <int N>
+        inline auto simplex(const unoriented_simplex_t<N> & footprint, bool orientation)
+            -> simplex_t<N>;
 
         // return a simplex with composition {composition} (either create a new simplex if such
         // simplex does not exist in the factory or return the existing representative of the class
         // of equivalence of simplices with this composition)
-        template <int D>
-        inline auto simplex(const simplex_composition_t<D> & composition) -> simplex_t<D>
-        requires(D > 0);
+        template <int N>
+        inline auto simplex(const simplex_composition_t<N> & composition) -> simplex_t<N>
+        requires(N > 0);
 
-        template <int D>
+        template <int N>
         inline auto simplex(bool orientation) -> simplex_t<0>
-        requires(D == 0);
+        requires(N == 0);
 
         // instantiate a vertex
         inline auto vertex() -> vertex_t;
@@ -61,40 +61,40 @@ namespace mito::topology {
         inline auto tetrahedron(const vertex_simplex_composition_t<3> & vertices) -> simplex_t<3>;
 
         // returns whether the oriented simplex exists in the factory
-        template <int D>
-        inline auto exists(const simplex_composition_t<D> & simplices) const -> bool;
+        template <int N>
+        inline auto exists(const simplex_composition_t<N> & simplices) const -> bool;
 
         // returns whether the segment exists in the factory
         inline auto exists(const vertex_simplex_composition_t<1> & vertices) const -> bool;
 
         // returns whether there exists the flipped oriented simplex in the factory
-        template <int D>
-        inline auto exists_flipped(const simplex_t<D> & simplex) const -> bool;
+        template <int N>
+        inline auto exists_flipped(const simplex_t<N> & simplex) const -> bool;
 
         // returns the simplex with opposite orientation
-        template <int D>
-        inline auto flip(const simplex_t<D> & simplex) -> simplex_t<D>;
+        template <int N>
+        inline auto flip(const simplex_t<N> & simplex) -> simplex_t<N>;
 
       private:
-        template <int D>
-        inline auto _erase(simplex_t<D> & simplex) -> void
-        requires(D == 0);
+        template <int N>
+        inline auto _erase(simplex_t<N> & simplex) -> void
+        requires(N == 0);
 
-        template <int D>
-        inline auto _erase(simplex_t<D> & simplex) -> void
-        requires(D > 0);
+        template <int N>
+        inline auto _erase(simplex_t<N> & simplex) -> void
+        requires(N > 0);
 
-        // mutator for the simplex factory of dimension D
-        template <int D>
-        inline auto _get_factory() noexcept -> oriented_simplex_factory_t<D> &;
+        // mutator for the simplex factory of dimension N
+        template <int N>
+        inline auto _get_factory() noexcept -> oriented_simplex_factory_t<N> &;
 
-        // accessor for the simplex factory of dimension D
-        template <int D>
-        inline auto _get_factory() const noexcept -> const oriented_simplex_factory_t<D> &;
+        // accessor for the simplex factory of dimension N
+        template <int N>
+        inline auto _get_factory() const noexcept -> const oriented_simplex_factory_t<N> &;
 
       public:
-        template <int D>
-        inline auto erase(simplex_t<D> & simplex) -> void;
+        template <int N>
+        inline auto erase(simplex_t<N> & simplex) -> void;
 
       private:
         // factory for vertices

--- a/lib/mito/topology/Topology.h
+++ b/lib/mito/topology/Topology.h
@@ -26,42 +26,40 @@ namespace mito::topology {
       public:
         template <int D>
         inline auto simplex(const unoriented_simplex_t<D> & footprint, bool orientation)
-            -> const simplex_t<D> &;
+            -> simplex_t<D> &;
 
         // return a simplex with composition {composition} (either create a new simplex if such
         // simplex does not exist in the factory or return the existing representative of the class
         // of equivalence of simplices with this composition)
         template <int D>
-        inline auto simplex(const simplex_composition_t<D> & composition) -> const simplex_t<D> &
+        inline auto simplex(const simplex_composition_t<D> & composition) -> simplex_t<D> &
         requires(D > 0);
 
         template <int D>
-        inline auto simplex(bool orientation) -> const simplex_t<0> &
+        inline auto simplex(bool orientation) -> simplex_t<0> &
         requires(D == 0);
 
         // instantiate a vertex
+        // TOFIX: inconsistency with consts?
         inline auto vertex() -> const vertex_t &;
 
         // instantiate a segment
-        inline auto segment(const simplex_composition_t<1> & simplices) -> const simplex_t<1> &;
+        inline auto segment(const simplex_composition_t<1> & simplices) -> simplex_t<1> &;
 
         // instantiate a triangle
-        inline auto triangle(const simplex_composition_t<2> & simplices) -> const simplex_t<2> &;
+        inline auto triangle(const simplex_composition_t<2> & simplices) -> simplex_t<2> &;
 
         // instantiate a tetrahedron
-        inline auto tetrahedron(const simplex_composition_t<3> & simplices) -> const simplex_t<3> &;
+        inline auto tetrahedron(const simplex_composition_t<3> & simplices) -> simplex_t<3> &;
 
         // instantiate a segment from unoriented vertices
-        inline auto segment(const vertex_simplex_composition_t<1> & simplices)
-            -> const simplex_t<1> &;
+        inline auto segment(const vertex_simplex_composition_t<1> & simplices) -> simplex_t<1> &;
 
         // instantiate a triangle
-        inline auto triangle(const vertex_simplex_composition_t<2> & vertices)
-            -> const simplex_t<2> &;
+        inline auto triangle(const vertex_simplex_composition_t<2> & vertices) -> simplex_t<2> &;
 
         // instantiate a tetrahedron
-        inline auto tetrahedron(const vertex_simplex_composition_t<3> & vertices)
-            -> const simplex_t<3> &;
+        inline auto tetrahedron(const vertex_simplex_composition_t<3> & vertices) -> simplex_t<3> &;
 
         // returns whether the oriented simplex exists in the factory
         template <int D>
@@ -76,15 +74,15 @@ namespace mito::topology {
 
         // returns the simplex with opposite orientation
         template <int D>
-        inline auto flip(const simplex_t<D> & simplex) -> const simplex_t<D> &;
+        inline auto flip(const simplex_t<D> & simplex) -> simplex_t<D> &;
 
       private:
         template <int D>
-        inline auto _erase(const simplex_t<D> & simplex) -> void
+        inline auto _erase(simplex_t<D> & simplex) -> void
         requires(D == 0);
 
         template <int D>
-        inline auto _erase(const simplex_t<D> & simplex) -> void
+        inline auto _erase(simplex_t<D> & simplex) -> void
         requires(D > 0);
 
         // mutator for the simplex factory of dimension D
@@ -97,7 +95,7 @@ namespace mito::topology {
 
       public:
         template <int D>
-        inline auto erase(const simplex_t<D> & simplex) -> void;
+        inline auto erase(simplex_t<D> & simplex) -> void;
 
       private:
         // factory for vertices

--- a/lib/mito/topology/Topology.h
+++ b/lib/mito/topology/Topology.h
@@ -26,40 +26,39 @@ namespace mito::topology {
       public:
         template <int D>
         inline auto simplex(const unoriented_simplex_t<D> & footprint, bool orientation)
-            -> simplex_t<D> &;
+            -> simplex_t<D>;
 
         // return a simplex with composition {composition} (either create a new simplex if such
         // simplex does not exist in the factory or return the existing representative of the class
         // of equivalence of simplices with this composition)
         template <int D>
-        inline auto simplex(const simplex_composition_t<D> & composition) -> simplex_t<D> &
+        inline auto simplex(const simplex_composition_t<D> & composition) -> simplex_t<D>
         requires(D > 0);
 
         template <int D>
-        inline auto simplex(bool orientation) -> simplex_t<0> &
+        inline auto simplex(bool orientation) -> simplex_t<0>
         requires(D == 0);
 
         // instantiate a vertex
-        // TOFIX: inconsistency with consts?
-        inline auto vertex() -> const vertex_t &;
+        inline auto vertex() -> vertex_t;
 
         // instantiate a segment
-        inline auto segment(const simplex_composition_t<1> & simplices) -> simplex_t<1> &;
+        inline auto segment(const simplex_composition_t<1> & simplices) -> simplex_t<1>;
 
         // instantiate a triangle
-        inline auto triangle(const simplex_composition_t<2> & simplices) -> simplex_t<2> &;
+        inline auto triangle(const simplex_composition_t<2> & simplices) -> simplex_t<2>;
 
         // instantiate a tetrahedron
-        inline auto tetrahedron(const simplex_composition_t<3> & simplices) -> simplex_t<3> &;
+        inline auto tetrahedron(const simplex_composition_t<3> & simplices) -> simplex_t<3>;
 
         // instantiate a segment from unoriented vertices
-        inline auto segment(const vertex_simplex_composition_t<1> & simplices) -> simplex_t<1> &;
+        inline auto segment(const vertex_simplex_composition_t<1> & simplices) -> simplex_t<1>;
 
         // instantiate a triangle
-        inline auto triangle(const vertex_simplex_composition_t<2> & vertices) -> simplex_t<2> &;
+        inline auto triangle(const vertex_simplex_composition_t<2> & vertices) -> simplex_t<2>;
 
         // instantiate a tetrahedron
-        inline auto tetrahedron(const vertex_simplex_composition_t<3> & vertices) -> simplex_t<3> &;
+        inline auto tetrahedron(const vertex_simplex_composition_t<3> & vertices) -> simplex_t<3>;
 
         // returns whether the oriented simplex exists in the factory
         template <int D>
@@ -74,7 +73,7 @@ namespace mito::topology {
 
         // returns the simplex with opposite orientation
         template <int D>
-        inline auto flip(const simplex_t<D> & simplex) -> simplex_t<D> &;
+        inline auto flip(const simplex_t<D> & simplex) -> simplex_t<D>;
 
       private:
         template <int D>

--- a/lib/mito/topology/Topology.icc
+++ b/lib/mito/topology/Topology.icc
@@ -69,28 +69,28 @@ mito::topology::Topology::_get_factory<3>() const noexcept -> const oriented_sim
     return _tetrahedron_factory;
 }
 
-template <int D>
+template <int N>
 inline auto
-mito::topology::Topology::simplex(const unoriented_simplex_t<D> & footprint, bool orientation)
-    -> simplex_t<D>
+mito::topology::Topology::simplex(const unoriented_simplex_t<N> & footprint, bool orientation)
+    -> simplex_t<N>
 {
     // ask the factory of oriented simplices
-    return _get_factory<D>().orientedSimplex(footprint, orientation);
+    return _get_factory<N>().orientedSimplex(footprint, orientation);
 }
 
-template <int D>
+template <int N>
 inline auto
-mito::topology::Topology::simplex(const simplex_composition_t<D> & composition) -> simplex_t<D>
-requires(D > 0)
+mito::topology::Topology::simplex(const simplex_composition_t<N> & composition) -> simplex_t<N>
+requires(N > 0)
 {
     // ask the factory of oriented simplices
-    return _get_factory<D>().orientedSimplex(composition);
+    return _get_factory<N>().orientedSimplex(composition);
 }
 
-template <int D>
+template <int N>
 inline auto
 mito::topology::Topology::simplex(bool orientation) -> simplex_t<0>
-requires(D == 0)
+requires(N == 0)
 {
     // ask the factory of oriented simplices
     return _get_factory<0>().orientedSimplex(orientation);
@@ -138,37 +138,37 @@ mito::topology::Topology::tetrahedron(const vertex_simplex_composition_t<3> & ve
                         triangle({ vertices[0], vertices[2], vertices[1] }) });
 }
 
-template <int D>
+template <int N>
 inline auto
-mito::topology::Topology::exists_flipped(const simplex_t<D> & simplex) const -> bool
+mito::topology::Topology::exists_flipped(const simplex_t<N> & simplex) const -> bool
 {
-    return _get_factory<D>().existsOrientedSimplex(simplex->footprint(), !simplex->orientation());
+    return _get_factory<N>().existsOrientedSimplex(simplex->footprint(), !simplex->orientation());
 }
 
-template <int D>
+template <int N>
 inline auto
-mito::topology::Topology::flip(const simplex_t<D> & simplex) -> simplex_t<D>
+mito::topology::Topology::flip(const simplex_t<N> & simplex) -> simplex_t<N>
 {
     // ask the factory of oriented simplices
-    return _get_factory<D>().orientedSimplex(simplex->footprint(), !simplex->orientation());
+    return _get_factory<N>().orientedSimplex(simplex->footprint(), !simplex->orientation());
 }
 
-template <int D>
+template <int N>
 inline auto
-mito::topology::Topology::_erase(simplex_t<D> & simplex) -> void
-requires(D == 0)
+mito::topology::Topology::_erase(simplex_t<N> & simplex) -> void
+requires(N == 0)
 {
     // erase the vertex from the factory
-    _get_factory<D>().erase(simplex);
+    _get_factory<N>().erase(simplex);
 
     // all done
     return;
 }
 
-template <int D>
+template <int N>
 inline auto
-mito::topology::Topology::_erase(simplex_t<D> & simplex) -> void
-requires(D > 0)
+mito::topology::Topology::_erase(simplex_t<N> & simplex) -> void
+requires(N > 0)
 {
     // QUESTION: method {reset} is not {const} unless the {_handle} of the shared pointer is
     //          declared mutable. Should we call reset here and make the handle mutable or
@@ -182,7 +182,7 @@ requires(D > 0)
     auto composition = simplex->composition();
 
     // cleanup the oriented factory around {simplex}
-    _get_factory<D>().erase(simplex);
+    _get_factory<N>().erase(simplex);
 
     // loop on subsimplices
     for (auto & subsimplex : composition) {
@@ -198,9 +198,9 @@ requires(D > 0)
     return;
 }
 
-template <int D>
+template <int N>
 inline auto
-mito::topology::Topology::erase(simplex_t<D> & simplex) -> void
+mito::topology::Topology::erase(simplex_t<N> & simplex) -> void
 {
     // if someone else (other than the topology) is still using this resource
     if (simplex.references() > 1) {
@@ -219,11 +219,11 @@ mito::topology::Topology::vertex() -> vertex_t
     return _get_factory<0>().vertex();
 }
 
-template <int D>
+template <int N>
 inline auto
-mito::topology::Topology::exists(const simplex_composition_t<D> & simplices) const -> bool
+mito::topology::Topology::exists(const simplex_composition_t<N> & simplices) const -> bool
 {
-    return _get_factory<D>().existsOrientedSimplex(simplices);
+    return _get_factory<N>().existsOrientedSimplex(simplices);
 }
 
 inline auto

--- a/lib/mito/topology/Topology.icc
+++ b/lib/mito/topology/Topology.icc
@@ -158,6 +158,12 @@ inline auto
 mito::topology::Topology::_erase(simplex_t<N> & simplex) -> void
 requires(N == 0)
 {
+    // if this vertex is still being used
+    if (simplex.references() > 1) {
+        // do nothing
+        return;
+    }
+
     // erase the vertex from the factory
     _get_factory<N>().erase(simplex);
 
@@ -170,13 +176,11 @@ inline auto
 mito::topology::Topology::_erase(simplex_t<N> & simplex) -> void
 requires(N > 0)
 {
-    // QUESTION: method {reset} is not {const} unless the {_handle} of the shared pointer is
-    //          declared mutable. Should we call reset here and make the handle mutable or
-    //          should we accept that {element} points to an invalid resource after call to
-    //          {erase}?
-
-    // sanity check
-    assert(simplex.references() > 0);
+    // if this simplex is still being used
+    if (simplex.references() > 1) {
+        // do nothing
+        return;
+    }
 
     // grab a copy of the composition
     auto composition = simplex->composition();
@@ -186,11 +190,8 @@ requires(N > 0)
 
     // loop on subsimplices
     for (auto & subsimplex : composition) {
-        // if the copy I just made is the only remaining use of this simplex
-        if (subsimplex.references() == 1) {
-            // recursively erase the subsimplices
-            _erase(subsimplex);
-        }
+        // recursively erase the subsimplices
+        _erase(subsimplex);
     }
 
     // all done
@@ -201,11 +202,9 @@ template <int N>
 inline auto
 mito::topology::Topology::erase(simplex_t<N> & simplex) -> void
 {
-    // if someone else (other than the topology) is still using this resource
-    if (simplex.references() > 1) {
-        // do nothing
-        return;
-    }
+    // TOFIX: transform this into a nullptr check
+    // sanity check
+    assert(simplex.references() > 0);
 
     // otherwise, erase the simplex
     return _erase(simplex);

--- a/lib/mito/topology/Topology.icc
+++ b/lib/mito/topology/Topology.icc
@@ -186,9 +186,8 @@ requires(N > 0)
 
     // loop on subsimplices
     for (auto & subsimplex : composition) {
-        // if this simplex is the last one using the subsimplex (other than the copy we just
-        // did)
-        if (subsimplex.references() == 2) {
+        // if the copy I just made is the only remaining use of this simplex
+        if (subsimplex.references() == 1) {
             // recursively erase the subsimplices
             _erase(subsimplex);
         }

--- a/lib/mito/topology/Topology.icc
+++ b/lib/mito/topology/Topology.icc
@@ -72,7 +72,7 @@ mito::topology::Topology::_get_factory<3>() const noexcept -> const oriented_sim
 template <int D>
 inline auto
 mito::topology::Topology::simplex(const unoriented_simplex_t<D> & footprint, bool orientation)
-    -> simplex_t<D> &
+    -> simplex_t<D>
 {
     // ask the factory of oriented simplices
     return _get_factory<D>().orientedSimplex(footprint, orientation);
@@ -80,7 +80,7 @@ mito::topology::Topology::simplex(const unoriented_simplex_t<D> & footprint, boo
 
 template <int D>
 inline auto
-mito::topology::Topology::simplex(const simplex_composition_t<D> & composition) -> simplex_t<D> &
+mito::topology::Topology::simplex(const simplex_composition_t<D> & composition) -> simplex_t<D>
 requires(D > 0)
 {
     // ask the factory of oriented simplices
@@ -89,7 +89,7 @@ requires(D > 0)
 
 template <int D>
 inline auto
-mito::topology::Topology::simplex(bool orientation) -> simplex_t<0> &
+mito::topology::Topology::simplex(bool orientation) -> simplex_t<0>
 requires(D == 0)
 {
     // ask the factory of oriented simplices
@@ -97,33 +97,31 @@ requires(D == 0)
 }
 
 inline auto
-mito::topology::Topology::segment(const simplex_composition_t<1> & simplices) -> simplex_t<1> &
+mito::topology::Topology::segment(const simplex_composition_t<1> & simplices) -> simplex_t<1>
 {
     return simplex<1>(simplices);
 }
 
 inline auto
-mito::topology::Topology::triangle(const simplex_composition_t<2> & simplices) -> simplex_t<2> &
+mito::topology::Topology::triangle(const simplex_composition_t<2> & simplices) -> simplex_t<2>
 {
     return simplex<2>(simplices);
 }
 
 inline auto
-mito::topology::Topology::tetrahedron(const simplex_composition_t<3> & simplices) -> simplex_t<3> &
+mito::topology::Topology::tetrahedron(const simplex_composition_t<3> & simplices) -> simplex_t<3>
 {
     return simplex<3>(simplices);
 }
 
 inline auto
-mito::topology::Topology::segment(const vertex_simplex_composition_t<1> & simplices)
-    -> simplex_t<1> &
+mito::topology::Topology::segment(const vertex_simplex_composition_t<1> & simplices) -> simplex_t<1>
 {
     return segment({ simplex(simplices[0], false), simplex(simplices[1], true) });
 }
 
 inline auto
-mito::topology::Topology::triangle(const vertex_simplex_composition_t<2> & vertices)
-    -> simplex_t<2> &
+mito::topology::Topology::triangle(const vertex_simplex_composition_t<2> & vertices) -> simplex_t<2>
 {
     return simplex<2>({ segment({ vertices[0], vertices[1] }),
                         segment({ vertices[1], vertices[2] }),
@@ -132,7 +130,7 @@ mito::topology::Topology::triangle(const vertex_simplex_composition_t<2> & verti
 
 inline auto
 mito::topology::Topology::tetrahedron(const vertex_simplex_composition_t<3> & vertices)
-    -> simplex_t<3> &
+    -> simplex_t<3>
 {
     return simplex<3>({ triangle({ vertices[0], vertices[1], vertices[3] }),
                         triangle({ vertices[1], vertices[2], vertices[3] }),
@@ -149,7 +147,7 @@ mito::topology::Topology::exists_flipped(const simplex_t<D> & simplex) const -> 
 
 template <int D>
 inline auto
-mito::topology::Topology::flip(const simplex_t<D> & simplex) -> simplex_t<D> &
+mito::topology::Topology::flip(const simplex_t<D> & simplex) -> simplex_t<D>
 {
     // ask the factory of oriented simplices
     return _get_factory<D>().orientedSimplex(simplex->footprint(), !simplex->orientation());
@@ -215,7 +213,7 @@ mito::topology::Topology::erase(simplex_t<D> & simplex) -> void
 }
 
 inline auto
-mito::topology::Topology::vertex() -> const vertex_t &
+mito::topology::Topology::vertex() -> vertex_t
 {
     // ask the factory of vertices for an unoriented vertex
     return _get_factory<0>().vertex();

--- a/lib/mito/topology/Topology.icc
+++ b/lib/mito/topology/Topology.icc
@@ -72,7 +72,7 @@ mito::topology::Topology::_get_factory<3>() const noexcept -> const oriented_sim
 template <int D>
 inline auto
 mito::topology::Topology::simplex(const unoriented_simplex_t<D> & footprint, bool orientation)
-    -> const simplex_t<D> &
+    -> simplex_t<D> &
 {
     // ask the factory of oriented simplices
     return _get_factory<D>().orientedSimplex(footprint, orientation);
@@ -80,8 +80,7 @@ mito::topology::Topology::simplex(const unoriented_simplex_t<D> & footprint, boo
 
 template <int D>
 inline auto
-mito::topology::Topology::simplex(const simplex_composition_t<D> & composition)
-    -> const simplex_t<D> &
+mito::topology::Topology::simplex(const simplex_composition_t<D> & composition) -> simplex_t<D> &
 requires(D > 0)
 {
     // ask the factory of oriented simplices
@@ -90,7 +89,7 @@ requires(D > 0)
 
 template <int D>
 inline auto
-mito::topology::Topology::simplex(bool orientation) -> const simplex_t<0> &
+mito::topology::Topology::simplex(bool orientation) -> simplex_t<0> &
 requires(D == 0)
 {
     // ask the factory of oriented simplices
@@ -98,36 +97,33 @@ requires(D == 0)
 }
 
 inline auto
-mito::topology::Topology::segment(const simplex_composition_t<1> & simplices)
-    -> const simplex_t<1> &
+mito::topology::Topology::segment(const simplex_composition_t<1> & simplices) -> simplex_t<1> &
 {
     return simplex<1>(simplices);
 }
 
 inline auto
-mito::topology::Topology::triangle(const simplex_composition_t<2> & simplices)
-    -> const simplex_t<2> &
+mito::topology::Topology::triangle(const simplex_composition_t<2> & simplices) -> simplex_t<2> &
 {
     return simplex<2>(simplices);
 }
 
 inline auto
-mito::topology::Topology::tetrahedron(const simplex_composition_t<3> & simplices)
-    -> const simplex_t<3> &
+mito::topology::Topology::tetrahedron(const simplex_composition_t<3> & simplices) -> simplex_t<3> &
 {
     return simplex<3>(simplices);
 }
 
 inline auto
 mito::topology::Topology::segment(const vertex_simplex_composition_t<1> & simplices)
-    -> const simplex_t<1> &
+    -> simplex_t<1> &
 {
     return segment({ simplex(simplices[0], false), simplex(simplices[1], true) });
 }
 
 inline auto
 mito::topology::Topology::triangle(const vertex_simplex_composition_t<2> & vertices)
-    -> const simplex_t<2> &
+    -> simplex_t<2> &
 {
     return simplex<2>({ segment({ vertices[0], vertices[1] }),
                         segment({ vertices[1], vertices[2] }),
@@ -136,7 +132,7 @@ mito::topology::Topology::triangle(const vertex_simplex_composition_t<2> & verti
 
 inline auto
 mito::topology::Topology::tetrahedron(const vertex_simplex_composition_t<3> & vertices)
-    -> const simplex_t<3> &
+    -> simplex_t<3> &
 {
     return simplex<3>({ triangle({ vertices[0], vertices[1], vertices[3] }),
                         triangle({ vertices[1], vertices[2], vertices[3] }),
@@ -153,7 +149,7 @@ mito::topology::Topology::exists_flipped(const simplex_t<D> & simplex) const -> 
 
 template <int D>
 inline auto
-mito::topology::Topology::flip(const simplex_t<D> & simplex) -> const simplex_t<D> &
+mito::topology::Topology::flip(const simplex_t<D> & simplex) -> simplex_t<D> &
 {
     // ask the factory of oriented simplices
     return _get_factory<D>().orientedSimplex(simplex->footprint(), !simplex->orientation());
@@ -161,7 +157,7 @@ mito::topology::Topology::flip(const simplex_t<D> & simplex) -> const simplex_t<
 
 template <int D>
 inline auto
-mito::topology::Topology::_erase(const simplex_t<D> & simplex) -> void
+mito::topology::Topology::_erase(simplex_t<D> & simplex) -> void
 requires(D == 0)
 {
     // erase the vertex from the factory
@@ -173,7 +169,7 @@ requires(D == 0)
 
 template <int D>
 inline auto
-mito::topology::Topology::_erase(const simplex_t<D> & simplex) -> void
+mito::topology::Topology::_erase(simplex_t<D> & simplex) -> void
 requires(D > 0)
 {
     // QUESTION: method {reset} is not {const} unless the {_handle} of the shared pointer is
@@ -191,7 +187,7 @@ requires(D > 0)
     _get_factory<D>().erase(simplex);
 
     // loop on subsimplices
-    for (const auto & subsimplex : composition) {
+    for (auto & subsimplex : composition) {
         // if this simplex is the last one using the subsimplex (other than the copy we just
         // did)
         if (subsimplex.references() == 2) {
@@ -206,7 +202,7 @@ requires(D > 0)
 
 template <int D>
 inline auto
-mito::topology::Topology::erase(const simplex_t<D> & simplex) -> void
+mito::topology::Topology::erase(simplex_t<D> & simplex) -> void
 {
     // if someone else (other than the topology) is still using this resource
     if (simplex.references() > 1) {

--- a/lib/mito/topology/Topology.icc
+++ b/lib/mito/topology/Topology.icc
@@ -158,12 +158,6 @@ inline auto
 mito::topology::Topology::_erase(simplex_t<N> & simplex) -> void
 requires(N == 0)
 {
-    // if this vertex is still being used
-    if (simplex.references() > 1) {
-        // do nothing
-        return;
-    }
-
     // erase the vertex from the factory
     _get_factory<N>().erase(simplex);
 
@@ -176,21 +170,14 @@ inline auto
 mito::topology::Topology::_erase(simplex_t<N> & simplex) -> void
 requires(N > 0)
 {
-    // if this simplex is still being used
-    if (simplex.references() > 1) {
-        // do nothing
-        return;
-    }
-
     // grab a copy of the composition
     auto composition = simplex->composition();
 
     // cleanup the oriented factory around {simplex}
     _get_factory<N>().erase(simplex);
 
-    // loop on subsimplices
+    // recursively erase the subsimplices
     for (auto & subsimplex : composition) {
-        // recursively erase the subsimplices
         _erase(subsimplex);
     }
 

--- a/lib/mito/topology/Topology.icc
+++ b/lib/mito/topology/Topology.icc
@@ -189,9 +189,11 @@ template <int N>
 inline auto
 mito::topology::Topology::erase(simplex_t<N> & simplex) -> void
 {
-    // TOFIX: transform this into a nullptr check
-    // sanity check
-    assert(simplex.references() > 0);
+    // if the resource is not a valid one
+    if (simplex.is_nullptr()) {
+        // do nothing
+        return;
+    }
 
     // otherwise, erase the simplex
     return _erase(simplex);

--- a/lib/mito/topology/api.h
+++ b/lib/mito/topology/api.h
@@ -6,8 +6,8 @@
 namespace mito::topology {
 
     // simplex alias
-    template <int D>
-    using simplex_t = oriented_simplex_t<D>;
+    template <int N>
+    using simplex_t = oriented_simplex_t<N>;
 
     // vertex alias
     using vertex_t = unoriented_simplex_t<0>;

--- a/lib/mito/topology/api.h
+++ b/lib/mito/topology/api.h
@@ -20,23 +20,6 @@ namespace mito::topology {
 
     // tetrahedron alias
     using tetrahedron_t = simplex_t<3>;
-
-    // id type of an oriented simplex
-    template <int D>
-    using simplex_id_t = oriented_simplex_id_t<D>;
-
-    // id type of a vertex
-    template <int D>
-    using vertex_id_t = unoriented_simplex_id_t<D>;
-
-    // id type of a segment
-    using segment_id_t = simplex_id_t<1>;
-
-    // triangle alias
-    using triangle_id_t = simplex_id_t<2>;
-
-    // tetrahedron alias
-    using tetrahedron_id_t = simplex_id_t<3>;
 }
 
 

--- a/lib/mito/topology/flipdiagonal.h
+++ b/lib/mito/topology/flipdiagonal.h
@@ -133,8 +133,8 @@ namespace mito::topology {
         assert(headTailConnected(new_simplex_composition_1[2], new_simplex_composition_1[0]));
 
         // build new simplices
-        auto & new_simplex0 = topology.triangle(new_simplex_composition_0);
-        auto & new_simplex1 = topology.triangle(new_simplex_composition_1);
+        auto new_simplex0 = topology.triangle(new_simplex_composition_0);
+        auto new_simplex1 = topology.triangle(new_simplex_composition_1);
 
         // all done
         return std::make_pair(new_simplex0, new_simplex1);

--- a/lib/mito/topology/forward1.h
+++ b/lib/mito/topology/forward1.h
@@ -6,28 +6,28 @@
 namespace mito::topology {
 
     // class simplex
-    template <int D>
+    template <int N>
     class Simplex;
 
     // class oriented simplex
-    template <int D>
+    template <int N>
     class OrientedSimplex;
 
     // class simplex factory
-    template <int D>
+    template <int N>
     class SimplexFactory;
 
     // simplex factory alias
-    template <int D>
-    using simplex_factory_t = SimplexFactory<D>;
+    template <int N>
+    using simplex_factory_t = SimplexFactory<N>;
 
     // class oriented simplex factory
-    template <int D>
+    template <int N>
     class OrientedSimplexFactory;
 
     // oriented simplex factory alias
-    template <int D>
-    using oriented_simplex_factory_t = OrientedSimplexFactory<D>;
+    template <int N>
+    using oriented_simplex_factory_t = OrientedSimplexFactory<N>;
 
     // class topology
     class Topology;
@@ -46,12 +46,12 @@ namespace mito::topology {
     using element_vector_t = std::vector<cellT>;
 
     // unoriented simplex alias
-    template <int D>
-    using unoriented_simplex_t = utilities::shared_ptr<const Simplex<D>>;
+    template <int N>
+    using unoriented_simplex_t = utilities::shared_ptr<const Simplex<N>>;
 
     // oriented simplex alias
-    template <int D>
-    using oriented_simplex_t = utilities::shared_ptr<const OrientedSimplex<D>>;
+    template <int N>
+    using oriented_simplex_t = utilities::shared_ptr<const OrientedSimplex<N>>;
 }
 
 

--- a/lib/mito/topology/forward1.h
+++ b/lib/mito/topology/forward1.h
@@ -47,11 +47,11 @@ namespace mito::topology {
 
     // unoriented simplex alias
     template <int D>
-    using unoriented_simplex_t = utilities::shared_ptr<Simplex<D>>;
+    using unoriented_simplex_t = utilities::shared_ptr<const Simplex<D>>;
 
     // oriented simplex alias
     template <int D>
-    using oriented_simplex_t = utilities::shared_ptr<OrientedSimplex<D>>;
+    using oriented_simplex_t = utilities::shared_ptr<const OrientedSimplex<D>>;
 }
 
 

--- a/lib/mito/topology/forward1.h
+++ b/lib/mito/topology/forward1.h
@@ -52,14 +52,6 @@ namespace mito::topology {
     // oriented simplex alias
     template <int D>
     using oriented_simplex_t = utilities::shared_ptr<OrientedSimplex<D>>;
-
-    // id type of unoriented simplex
-    template <int D>
-    using unoriented_simplex_id_t = utilities::index_t<unoriented_simplex_t<D>>;
-
-    // id type of unoriented simplex
-    template <int D>
-    using oriented_simplex_id_t = utilities::index_t<oriented_simplex_t<D>>;
 }
 
 

--- a/lib/mito/topology/forward2.h
+++ b/lib/mito/topology/forward2.h
@@ -6,14 +6,14 @@
 namespace mito::topology {
 
     // alias for oriented simplex recursive composition
-    // (e.g. a D-simplex has D+1 (D-1)-simplices)
-    template <int D>
-    using simplex_composition_t = std::array<oriented_simplex_t<D - 1>, D + 1>;
+    // (e.g. a N-simplex has N+1 (N-1)-simplices)
+    template <int N>
+    using simplex_composition_t = std::array<oriented_simplex_t<N - 1>, N + 1>;
 
     // alias for oriented simplex composition in terms of vertices
     // (e.g. a D-simplex has D + 1 0-simplices, i.e. vertices)
-    template <int D>
-    using vertex_simplex_composition_t = std::array<vertex_t, D + 1>;
+    template <int N>
+    using vertex_simplex_composition_t = std::array<vertex_t, N + 1>;
 
     // vertex set alias
     using vertex_set_t = element_set_t<vertex_t>;

--- a/lib/mito/topology/utilities.h
+++ b/lib/mito/topology/utilities.h
@@ -5,8 +5,8 @@
 
 namespace mito::topology {
     // overload operator<< for oriented simplices
-    template <int D>
-    std::ostream & operator<<(std::ostream & os, const simplex_t<D> & s)
+    template <int N>
+    std::ostream & operator<<(std::ostream & os, const simplex_t<N> & s)
     {
         // print orientation
         os << "orientation: " << s->orientation() << std::endl;
@@ -17,9 +17,9 @@ namespace mito::topology {
     }
 
     // overload operator<< for simplices
-    template <int D>
-    std::ostream & operator<<(std::ostream & os, const unoriented_simplex_t<D> & s)
-    requires(D > 0)
+    template <int N>
+    std::ostream & operator<<(std::ostream & os, const unoriented_simplex_t<N> & s)
+    requires(N > 0)
     {
         os << s.id() << " composed of:" << std::endl;
         for (const auto & simplex : s->composition()) {

--- a/lib/mito/topology/utilities.h
+++ b/lib/mito/topology/utilities.h
@@ -4,6 +4,24 @@
 
 
 namespace mito::topology {
+    // order of simplex
+    template <class cellT>
+    constexpr auto order() -> int
+    {
+        return cellT::resource_type::order;
+    }
+
+    // number of vertices of simplex
+    template <class cellT>
+    constexpr auto n_vertices() -> int
+    {
+        return cellT::resource_type::n_vertices;
+    }
+
+    // cell family of simplex
+    template <class cellT, int I>
+    using cell_family = typename cellT::resource_type::template cell_family_type<I>;
+
     // overload operator<< for oriented simplices
     template <int N>
     std::ostream & operator<<(std::ostream & os, const simplex_t<N> & s)

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -81,6 +81,34 @@ namespace mito::utilities {
             return _resources;
         }
 
+      public:
+        /**
+         * iterators
+         */
+        constexpr auto begin()
+        {
+            // delegate answer to {_resources}
+            return _resources.begin();
+        }
+
+        constexpr auto end()
+        {
+            // delegate answer to {_resources}
+            return _resources.end();
+        }
+
+        constexpr auto begin() const
+        {
+            // delegate answer to {_resources}
+            return _resources.begin();
+        }
+
+        constexpr auto end() const
+        {
+            // delegate answer to {_resources}
+            return _resources.end();
+        }
+
       private:
         // container to store the resources
         resource_collection_t _resources;

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -27,11 +27,9 @@ namespace mito::utilities {
         // destructor
         ~Repository()
         {
-            if (std::size(_resources) > 0) {
-                // destroy all resources
-                for (const auto & resource : _resources) {
-                    resource.~resource_t();
-                }
+            // destroy all resources
+            for (const auto & resource : _resources) {
+                resource.~resource_t();
             }
         }
 

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -27,9 +27,9 @@ namespace mito::utilities {
         // destructor
         ~Repository()
         {
-            // destroy all resources
-            for (const auto & resource : _resources) {
-                resource.~resource_t();
+            // destroy all valid resources
+            for (const auto & resource : *this) {
+                resource->~resource_t();
             }
         }
 

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -8,11 +8,17 @@ namespace mito::utilities {
     class Repository {
         // requires ReferenceCountedObject<sharedResourceT::resource_type>
       public:
+        // me
+        using repository_type = Repository<sharedResourceT>;
+        // the shared resource
         using shared_ptr_t = sharedResourceT;
         // my resource type
         using resource_t = typename sharedResourceT::resource_type;
         // typedef for a collection of resources
-        using resource_collection_t = segmented_t<sharedResourceT>;
+        using resource_collection_t = segmented_t<resource_t>;
+
+        // iterators
+        using iterator = RepositoryIterator<repository_type>;
 
       public:
         // default constructor
@@ -35,7 +41,7 @@ namespace mito::utilities {
         auto emplace(Args &&... args) -> shared_ptr_t
         {
             // get a spare location for the placement of the new resource
-            auto location = _resources._location_for_placement();
+            auto location = _resources.location_for_placement();
 
             // create a new instance of {resource_t} at location {location} with placement new
             resource_t * resource = new (location) resource_t(args...);
@@ -85,16 +91,16 @@ namespace mito::utilities {
         /**
          * iterators
          */
-        constexpr auto begin() const
+        constexpr auto begin() const -> iterator
         {
             // delegate answer to {_resources}
-            return _resources.begin();
+            return iterator(_resources.begin());
         }
 
-        constexpr auto end() const
+        constexpr auto end() const -> iterator
         {
             // delegate answer to {_resources}
-            return _resources.end();
+            return iterator(_resources.end());
         }
 
       private:

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -1,0 +1,80 @@
+// code guard
+#if !defined(mito_utilities_Repository_h)
+#define mito_utilities_Repository_h
+
+namespace mito::utilities {
+
+    template <class resourceT>
+    class Repository {
+      public:
+        // my resource type
+        using resource_t = resourceT;
+        // typedef for a collection of resources
+        using resource_collection_t = segmented_t<shared_ptr<resource_t>>;
+
+      public:
+        // default constructor
+        Repository(int segment_size) : _resources(segment_size) {};
+
+        // destructor
+        ~Repository()
+        {
+            // destroy all resources
+            for (const auto & resource : _resources) {
+                resource->~resource_t();
+            }
+        }
+
+        // build a resource passing down {args...} to the resource constructor and store it in the
+        // repository
+        template <class... Args>
+        auto emplace(Args &&... args) -> shared_ptr<resource_t>
+        {
+            // get a spare location for the placement of the new resource
+            auto location = _resources._location_for_placement();
+
+            // create a new instance of {resource_t} at location {location} with placement new
+            resource_t * resource = new (location) resource_t(args...);
+
+            // assign it to a new pointer
+            shared_ptr<resource_t> pointer(resource);
+
+            // all done
+            return pointer;
+        }
+
+        // erase a resource from the repository
+        // (this method actually erases the simplex only if is no one else is using it, otherwise
+        // does nothing)
+        inline auto erase(shared_ptr<resource_t> & resource) -> void
+        {
+            // // if the repository is the last user of the resource
+            // if (resource.references() == 1) {
+            // remove this resource from the collection of resources
+            _resources._erase(resource);
+            // destroy the resource
+            resource->~resource_t();
+            // QUESTION: to reset or not to reset?
+            // reset the shared pointer to the resource
+            resource.reset();
+            // }
+
+            // all done
+            return;
+        }
+
+        inline auto resources() const -> const resource_collection_t &
+        {
+            // all done
+            return _resources;
+        }
+
+      private:
+        // container to store the resources
+        resource_collection_t _resources;
+    };
+}
+
+#endif    // mito_utilities_Repository_h
+
+// end of file

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -66,6 +66,15 @@ namespace mito::utilities {
             return;
         }
 
+        // returns the resource corresponding to this resource id
+        static inline auto resource(index_t<resource_t> index) -> shared_ptr<resource_t>
+        {
+            // fetch the resource based on the index
+            auto resource = shared_ptr<resource_t>::resource(index);
+            // wrap the resource in a shared pointer
+            return shared_ptr<resource_t>(resource);
+        }
+
         inline auto resources() const -> const resource_collection_t &
         {
             // all done

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -53,16 +53,14 @@ namespace mito::utilities {
         inline auto erase(shared_ptr_t & resource) -> void
         {
             // TOFIX: capture exception of invalid resource (nullptr)
-            // if the resource is valid
-            if (!resource.is_nullptr()) {
-                // remove this resource from the collection of resources
-                _resources.erase(resource.handle());
-                // destroy the resource
-                resource->~resource_t();
-                // QUESTION: to reset or not to reset?
-                // reset the shared pointer to the resource
-                resource.reset();
-            }
+            // sanity check
+            assert(!cell.is_nullptr());
+            // remove this resource from the collection of resources
+            _resources.erase(resource.handle());
+            // destroy the resource
+            resource->~resource_t();
+            // reset the shared pointer to the resource
+            resource.reset();
 
             // all done
             return;

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -82,6 +82,9 @@ namespace mito::utilities {
             // create a new instance of {resource_t} at location {location} with placement new
             resource_t * resource = new (location) resource_t(args...);
 
+            // add resource to the collection of resources
+            _resources.insert(resource);
+
             // assign it to a new pointer
             shared_ptr_t pointer(resource);
 

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -65,9 +65,9 @@ namespace mito::utilities {
         // destructor
         ~Repository()
         {
-            // destroy all valid resources
-            for (const auto & resource : *this) {
-                resource->~resource_t();
+            // destroy all resources
+            for (const auto & resource : _resources) {
+                resource.~resource_t();
             }
         }
 

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -19,9 +19,11 @@ namespace mito::utilities {
         // destructor
         ~Repository()
         {
-            // destroy all resources
-            for (const auto & resource : _resources) {
-                resource->~resource_t();
+            if (std::size(_resources) > 0) {
+                // destroy all resources
+                for (const auto & resource : _resources) {
+                    resource->~resource_t();
+                }
             }
         }
 
@@ -48,16 +50,17 @@ namespace mito::utilities {
         // does nothing)
         inline auto erase(shared_ptr<resource_t> & resource) -> void
         {
-            // // if the repository is the last user of the resource
-            // if (resource.references() == 1) {
-            // remove this resource from the collection of resources
-            _resources._erase(resource);
-            // destroy the resource
-            resource->~resource_t();
-            // QUESTION: to reset or not to reset?
-            // reset the shared pointer to the resource
-            resource.reset();
-            // }
+            // TOFIX: capture exception of invalid resource (nullptr)
+            // if the resource is valid
+            if (!resource.is_nullptr()) {
+                // remove this resource from the collection of resources
+                _resources._erase(resource.handle());
+                // destroy the resource
+                resource->~resource_t();
+                // QUESTION: to reset or not to reset?
+                // reset the shared pointer to the resource
+                resource.reset();
+            }
 
             // all done
             return;

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -54,7 +54,7 @@ namespace mito::utilities {
             // if the resource is valid
             if (!resource.is_nullptr()) {
                 // remove this resource from the collection of resources
-                _resources._erase(resource.handle());
+                _resources.erase(resource.handle());
                 // destroy the resource
                 resource->~resource_t();
                 // QUESTION: to reset or not to reset?

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -4,13 +4,14 @@
 
 namespace mito::utilities {
 
-    template <class resourceT>
+    template <class sharedResourceT>
     class Repository {
+        // requires ReferenceCountedObject<sharedResourceT::resource_t>
       public:
         // my resource type
-        using resource_t = resourceT;
+        using resource_t = typename sharedResourceT::resource_t;
         // typedef for a collection of resources
-        using resource_collection_t = segmented_t<shared_ptr<resource_t>>;
+        using resource_collection_t = segmented_t<sharedResourceT>;
 
       public:
         // default constructor

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -8,6 +8,7 @@ namespace mito::utilities {
     class Repository {
         // requires ReferenceCountedObject<sharedResourceT::resource_t>
       public:
+        using shared_ptr_t = sharedResourceT;
         // my resource type
         using resource_t = typename sharedResourceT::resource_t;
         // typedef for a collection of resources
@@ -31,7 +32,7 @@ namespace mito::utilities {
         // build a resource passing down {args...} to the resource constructor and store it in the
         // repository
         template <class... Args>
-        auto emplace(Args &&... args) -> shared_ptr<resource_t>
+        auto emplace(Args &&... args) -> shared_ptr_t
         {
             // get a spare location for the placement of the new resource
             auto location = _resources._location_for_placement();
@@ -40,7 +41,7 @@ namespace mito::utilities {
             resource_t * resource = new (location) resource_t(args...);
 
             // assign it to a new pointer
-            shared_ptr<resource_t> pointer(resource);
+            shared_ptr_t pointer(resource);
 
             // all done
             return pointer;
@@ -49,7 +50,7 @@ namespace mito::utilities {
         // erase a resource from the repository
         // (this method actually erases the simplex only if is no one else is using it, otherwise
         // does nothing)
-        inline auto erase(shared_ptr<resource_t> & resource) -> void
+        inline auto erase(shared_ptr_t & resource) -> void
         {
             // TOFIX: capture exception of invalid resource (nullptr)
             // if the resource is valid
@@ -68,12 +69,12 @@ namespace mito::utilities {
         }
 
         // returns the resource corresponding to this resource id
-        static inline auto resource(index_t<resource_t> index) -> shared_ptr<resource_t>
+        static inline auto resource(index_t<resource_t> index) -> shared_ptr_t
         {
             // fetch the resource based on the index
-            auto resource = shared_ptr<resource_t>::resource(index);
+            auto resource = shared_ptr_t::resource(index);
             // wrap the resource in a shared pointer
-            return shared_ptr<resource_t>(resource);
+            return shared_ptr_t(resource);
         }
 
         inline auto resources() const -> const resource_collection_t &

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -6,11 +6,11 @@ namespace mito::utilities {
 
     template <class sharedResourceT>
     class Repository {
-        // requires ReferenceCountedObject<sharedResourceT::resource_t>
+        // requires ReferenceCountedObject<sharedResourceT::resource_type>
       public:
         using shared_ptr_t = sharedResourceT;
         // my resource type
-        using resource_t = typename sharedResourceT::resource_t;
+        using resource_t = typename sharedResourceT::resource_type;
         // typedef for a collection of resources
         using resource_collection_t = segmented_t<sharedResourceT>;
 

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -60,13 +60,15 @@ namespace mito::utilities {
         {
             // TOFIX: capture exception of invalid resource (nullptr)
             // sanity check
-            assert(!cell.is_nullptr());
-            // remove this resource from the collection of resources
-            _resources.erase(resource.handle());
-            // destroy the resource
-            resource->~resource_t();
+            assert(!resource.is_nullptr());
+            // grab a copy of the pointed resource
+            auto handle = resource.handle();
             // reset the shared pointer to the resource
             resource.reset();
+            // remove this resource from the collection of resources
+            _resources.erase(handle);
+            // destroy the resource
+            handle->~resource_t();
 
             // all done
             return;

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -30,7 +30,7 @@ namespace mito::utilities {
             if (std::size(_resources) > 0) {
                 // destroy all resources
                 for (const auto & resource : _resources) {
-                    resource->~resource_t();
+                    resource.~resource_t();
                 }
             }
         }

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -87,18 +87,6 @@ namespace mito::utilities {
         /**
          * iterators
          */
-        constexpr auto begin()
-        {
-            // delegate answer to {_resources}
-            return _resources.begin();
-        }
-
-        constexpr auto end()
-        {
-            // delegate answer to {_resources}
-            return _resources.end();
-        }
-
         constexpr auto begin() const
         {
             // delegate answer to {_resources}

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -60,15 +60,13 @@ namespace mito::utilities {
         {
             // TOFIX: capture exception of invalid resource (nullptr)
             // sanity check
-            assert(!resource.is_nullptr());
-            // grab a copy of the pointed resource
-            auto handle = resource.handle();
+            assert(!cell.is_nullptr());
+            // remove this resource from the collection of resources
+            _resources.erase(resource.handle());
+            // destroy the resource
+            resource->~resource_t();
             // reset the shared pointer to the resource
             resource.reset();
-            // remove this resource from the collection of resources
-            _resources.erase(handle);
-            // destroy the resource
-            handle->~resource_t();
 
             // all done
             return;

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -60,7 +60,7 @@ namespace mito::utilities {
         {
             // TOFIX: capture exception of invalid resource (nullptr)
             // sanity check
-            assert(!cell.is_nullptr());
+            assert(!resource.is_nullptr());
             // remove this resource from the collection of resources
             _resources.erase(resource.handle());
             // destroy the resource

--- a/lib/mito/utilities/RepositoryIterator.h
+++ b/lib/mito/utilities/RepositoryIterator.h
@@ -40,7 +40,15 @@ namespace mito::utilities {
         // constructor
         constexpr RepositoryIterator(segmented_iterator_const_reference_type segmented_iterator) :
             _segmented_iterator(segmented_iterator)
-        {}
+        {
+            if (_segmented_iterator.ptr() != _segmented_iterator.end()) {
+                // if you found an invalid element
+                if (!_segmented_iterator->is_valid()) {
+                    // move on to the next one
+                    operator++();
+                }
+            }
+        }
 
         // iterator protocol
       public:
@@ -56,6 +64,16 @@ namespace mito::utilities {
         {
             // increment the iterator to the segmented container
             ++_segmented_iterator;
+
+            if (_segmented_iterator.ptr() == _segmented_iterator.end()) {
+                return *this;
+            }
+
+            // if you found an invalid element
+            if (!_segmented_iterator->is_valid()) {
+                // move on to the next one
+                return operator++();
+            }
 
             // all done
             return *this;

--- a/lib/mito/utilities/RepositoryIterator.h
+++ b/lib/mito/utilities/RepositoryIterator.h
@@ -1,0 +1,108 @@
+// -*- C++ -*-
+//
+
+
+// code guard
+#if !defined(mito_utilities_RepositoryIterator_h)
+#define mito_utilities_RepositoryIterator_h
+
+
+namespace mito::utilities {
+
+    template <class RepositoryT>
+    class RepositoryIterator {
+        // types
+      public:
+        // my template parameters
+        using repository_type = RepositoryT;
+        // me
+        using iterator = RepositoryIterator<repository_type>;
+        // a reference to me
+        using iterator_reference = iterator &;
+        // what I point to
+        using shared_pointer = typename repository_type::shared_ptr_t;
+
+        // the segmented container type
+        using segmented_type = typename repository_type::resource_collection_t;
+
+        // a reference to an iterator on the segmented container
+        using segmented_iterator_type = segmented_type::iterator;
+        using segmented_iterator_const_reference_type = segmented_type::iterator_const_reference;
+
+        // metamethods
+      public:
+        // constructor
+        constexpr RepositoryIterator(segmented_iterator_const_reference_type segmented_iterator) :
+            _segmented_iterator(segmented_iterator)
+        {}
+
+        // iterator protocol
+      public:
+        // dereference
+        constexpr auto operator*() const -> shared_pointer
+        {
+            // wrap the resource in a shared pointer and return it
+            return shared_pointer(_segmented_iterator.ptr());
+        }
+
+        // arithmetic: prefix
+        constexpr auto operator++() -> iterator_reference
+        {
+            // increment the iterator to the segmented container
+            ++_segmented_iterator;
+
+            // all done
+            return *this;
+        }
+
+        // arithmetic: postfix
+        constexpr auto operator++(int) -> iterator
+        {
+            // make a copy of me
+            auto clone = *this;
+            // increment me
+            ++_segmented_iterator;
+            // and return the clone
+            return clone;
+        }
+
+        // implementation details: data
+      private:
+        // a segmented container iterator
+        segmented_iterator_type _segmented_iterator;
+
+        // default metamethods
+      public:
+        // destructor
+        ~RepositoryIterator() = default;
+        // let the compiler write the rest
+        constexpr RepositoryIterator(const RepositoryIterator &) = default;
+        constexpr RepositoryIterator(RepositoryIterator &&) noexcept = default;
+        constexpr RepositoryIterator & operator=(const RepositoryIterator &) = default;
+        constexpr RepositoryIterator & operator=(RepositoryIterator &&) noexcept = default;
+    };
+
+    // the global operators
+    // equality
+    template <class RepositoryT>
+    constexpr auto operator==(
+        const RepositoryIterator<RepositoryT> & it1,
+        const RepositoryIterator<RepositoryT> & it2) noexcept -> bool
+    {
+        // iterators are equal if they point to the same thing
+        return *it1 == *it2;
+    }
+
+    // and not
+    template <class RepositoryT>
+    constexpr auto operator!=(
+        const RepositoryIterator<RepositoryT> & it1,
+        const RepositoryIterator<RepositoryT> & it2) noexcept -> bool
+    {
+        // iterators are unequal iff they are not equal
+        return !(it1 == it2);
+    }
+}
+#endif
+
+// end of file

--- a/lib/mito/utilities/RepositoryIterator.h
+++ b/lib/mito/utilities/RepositoryIterator.h
@@ -9,6 +9,12 @@
 
 namespace mito::utilities {
 
+    // forward declaration of repository iterator equality
+    template <class RepositoryT>
+    constexpr auto operator==(
+        const RepositoryIterator<RepositoryT> & it1,
+        const RepositoryIterator<RepositoryT> & it2) noexcept -> bool;
+
     template <class RepositoryT>
     class RepositoryIterator {
         // types
@@ -71,6 +77,11 @@ namespace mito::utilities {
         // a segmented container iterator
         segmented_iterator_type _segmented_iterator;
 
+        // befriend operator==
+        friend constexpr auto operator==<RepositoryT>(
+            const RepositoryIterator<RepositoryT> & it1,
+            const RepositoryIterator<RepositoryT> & it2) noexcept -> bool;
+
         // default metamethods
       public:
         // destructor
@@ -90,7 +101,7 @@ namespace mito::utilities {
         const RepositoryIterator<RepositoryT> & it2) noexcept -> bool
     {
         // iterators are equal if they point to the same thing
-        return *it1 == *it2;
+        return it1._segmented_iterator == it2._segmented_iterator;
     }
 
     // and not

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -231,16 +231,19 @@ namespace mito::utilities {
             return location;
         }
 
+        // TOFIX: adjust comments
+        // TOFIX: Segmented container should not know about shared pointers
+        // TOFIX: rename this function to {erase}
         // erase an element from the container
         // (decrement the number of elements and add the address of the element to the pile of the
         // available locations for reuse)
-        auto _erase(const shared_ptr<T> & element) -> void
+        auto _erase(T * element) -> void
         {
             // decrement the number of elements
             --_n_elements;
 
             // add the address of the element to the queue of the available locations for write
-            _available_locations.push(element.handle());
+            _available_locations.push(element);
 
             // all done
             return;

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -147,12 +147,6 @@ namespace mito::utilities {
                 // get an available location from the queue
                 pointer location = _available_locations.front();
 
-                // remove the next available location from the queue
-                // NOTE: for simplicity we make the assumption that the location returned by this
-                //      method then is actually used to construct a new element. That is why we
-                //      remove the item from the {_available_locations} container here.
-                _available_locations.pop();
-
                 // return the available location from the queue
                 return location;
             }
@@ -180,12 +174,6 @@ namespace mito::utilities {
                 location = _allocate_new_segment();
             }
 
-            // increment the size of the container
-            // NOTE: for simplicity we make the assumption that the location returned by this method
-            //      then is actually used to construct a new element. That is why we increment the
-            //      number of elements here
-            ++_n_elements;
-
             // if we have written past the last element
             if (location == _end) {
                 // move the end of the container
@@ -194,6 +182,26 @@ namespace mito::utilities {
 
             // all done
             return location;
+        }
+
+        // insert an element in the container
+        // (increment the number of elements and remove the address of the element from the pile of
+        // the available locations for reuse)
+        auto insert([[maybe_unused]] resource_type * element) -> void
+        {
+            // increment the size of the container
+            ++_n_elements;
+
+            // if there are available locations to spare
+            if (!_available_locations.empty()) {
+                // assert that the newly inserted element was inserted at the front of the queue
+                assert(const_cast<pointer>(element) == _available_locations.front());
+                // remove the next available location from the queue
+                _available_locations.pop();
+            }
+
+            // all done
+            return;
         }
 
         // erase an element from the container

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -66,16 +66,16 @@
 // been explored so far.
 
 namespace mito::utilities {
-    template <class T>
-    // requires ReferenceCountedObject<T>
+    template <class sharedResourceT>
+    // requires ReferenceCountedObject<sharedResourceT::resource_t>
     class SegmentedContainer {
 
       public:
-        // aliases for my template parameters
-        using resource_type = T;
-
         // me
-        using segmented_container_type = SegmentedContainer<resource_type>;
+        using segmented_container_type = SegmentedContainer<sharedResourceT>;
+
+        // aliases for my resource type
+        using resource_type = typename sharedResourceT::resource_t;
 
         // my value
         using pointer = resource_type *;
@@ -322,7 +322,7 @@ namespace mito::utilities {
         // const iterator
         friend const_iterator;
         // the repository
-        friend Repository<resource_type>;
+        friend Repository<sharedResourceT>;
     };
 }
 

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -221,13 +221,10 @@ namespace mito::utilities {
             return location;
         }
 
-        // TOFIX: adjust comments
-        // TOFIX: Segmented container should not know about shared pointers
-        // TOFIX: rename this function to {erase}
         // erase an element from the container
         // (decrement the number of elements and add the address of the element to the pile of the
         // available locations for reuse)
-        auto _erase(T * element) -> void
+        auto erase(T * element) -> void
         {
             // decrement the number of elements
             --_n_elements;

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -229,9 +229,6 @@ namespace mito::utilities {
         // available locations for reuse)
         auto erase(resource_type * element) -> void
         {
-            // assert that the element to be erased is invalid
-            assert(!element->is_valid());
-
             // decrement the number of elements
             --_n_elements;
 

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -67,7 +67,7 @@
 
 namespace mito::utilities {
     template <class sharedResourceT>
-    // requires ReferenceCountedObject<sharedResourceT::resource_t>
+    // requires ReferenceCountedObject<sharedResourceT::resource_type>
     class SegmentedContainer {
       public:
         // me
@@ -76,9 +76,9 @@ namespace mito::utilities {
         // aliases for my shared pointer type
         using shared_ptr_type = sharedResourceT;
         // and my (cv qualified) resource type
-        using resource_type = typename sharedResourceT::resource_t;
+        using resource_type = typename sharedResourceT::resource_type;
         // and my (cv qualified) handle type
-        using handle_type = typename sharedResourceT::handle_t;
+        using handle_type = typename sharedResourceT::handle_type;
 
         // unqualified resource type (for internal book-keeping)
         using unqualified_resource_type = typename std::remove_const<resource_type>::type;

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -235,7 +235,9 @@ namespace mito::utilities {
             return pointer;
         }
 
-        // This method is called by {shared_ptr::_release}
+        // erase an element from the container
+        // (decrement the number of elements and add the address of the element to the pile of the
+        // available locations for reuse)
         auto erase(const utilities::shared_ptr<T> & element) -> void
         {
             // assert that the resource is in valid state

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -247,7 +247,8 @@ namespace mito::utilities {
 
             // get an iterator to the first element
             auto it = iterator(
-                _begin /* ptr */, _begin + _segment_size /* segment_end */, _end /* end */, *this);
+                _begin /* ptr */, _begin + _segment_size /* segment_end */, _segment_size,
+                _end /* end */);
 
             // if the first element is valid, return it, else return the next valid element
             return (it->is_valid() ? it : ++it);
@@ -259,7 +260,7 @@ namespace mito::utilities {
             assert(_end_allocation - _end <= _segment_size);
             // make an {iterator} that points to the end of my segmented container
             return iterator(
-                _end /* ptr */, _end_allocation /* segment_end */, _end /* end */, *this);
+                _end /* ptr */, _end_allocation /* segment_end */, _segment_size, _end /* end */);
         }
 
         constexpr auto begin() const -> const_iterator
@@ -269,7 +270,8 @@ namespace mito::utilities {
 
             // get an iterator to the first element
             auto it = const_iterator(
-                _begin /* ptr */, _begin + _segment_size /* segment_end */, _end /* end */, *this);
+                _begin /* ptr */, _begin + _segment_size /* segment_end */, _segment_size,
+                _end /* end */);
 
             // if the first element is valid, return it, else return the next valid element
             return (it->is_valid() ? it : ++it);
@@ -281,7 +283,7 @@ namespace mito::utilities {
             assert(_end_allocation - _end <= _segment_size);
             // make an {iterator} that points to the end of my segmented container
             return const_iterator(
-                _end /* ptr */, _end_allocation /* segment_end */, _end /* end */, *this);
+                _end /* ptr */, _end_allocation /* segment_end */, _segment_size, _end /* end */);
         }
 
       private:

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -249,12 +249,9 @@ namespace mito::utilities {
             assert(_n_elements > 0);
 
             // get an iterator to the first element
-            auto it = iterator(
+            return iterator(
                 _begin /* ptr */, _begin + _segment_size /* segment_end */, _segment_size,
                 _end /* end */);
-
-            // if the first element is valid, return it, else return the next valid element
-            return (it->is_valid() ? it : ++it);
         }
 
         constexpr auto end() const -> iterator

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -6,64 +6,36 @@
 #if !defined(mito_utilities_SegmentedContainer_h)
 #define mito_utilities_SegmentedContainer_h
 
-// TOFIX: update design notes with {Repository} actor
 // DESIGN NOTES
 
 // Class {SegmentedContainer} implements a data structure that is resizable, while also being stable
-// in memory and able to concurrently instantiate multiple resources collectively.
-// While this data structure has been developed with the application in mind of collecting mesh
-// elements, the implementation is quite general and can be extended to storage of other type of
-// resources.
-
-// A {SegmentedContainer} is articulated in multiple segments of (contiguous) memory. Each segment
-// allocates memory for {_segment_size} resources of type {T}. Right at the end of each segment, a
-// pointer {T*} allows to reach the beginning of the next segment, much like what happens in linked
-// lists.
-
+// in memory and able to leverage the efficiency of concurrent contiguous memory allocation in
+// large chunks, as opposed to fragmented allocation.
+//
+// A {SegmentedContainer} is articulated in multiple segments of memory. Each segment is contiguous
+// in memory and consists of a memory allocation for {_segment_size} resources of type {T}. Right at
+// the end of each segment, a pointer {T*} points to the beginning of the next segment, much like
+// what happens in linked lists.
+//
+// The length of each segment, needs to be set by balancing the following trade-off:
+// - a larger segment size leads to a more compact data structure with a larger number of
+// elements lying adjacent to each other in memory and, in case of a fully populated segment, a
+// large segment size leads to a smaller allocation time per individual resource. Note, however,
+// that, in case of a non fully-populated segment, more resources than actually needed are
+// committed.
+// - a smaller segment size leads to a more scattered data structure and more memory allocation
+// calls, but certainly reduces redundancy in memory allocation.
+//
 // Resources are added to this container by place-instantiating them in the next available
 // location (if any). If the container is completely full, a new segment of memory is allocated
 // altogether.
-// Resources are removed from this container by marking the resource as 'invalid' and signing up
-// its position in memory to be overwritten by a new resource.
-
-// The length of each segment, needs to be set by balancing the following trade-off:
-// - a larger segment size leads to a more compact data structure with a larger number of elements
-// lying adjacent to each other in memory and, in case of a fully populated segment, a large segment
-// size leads to a smaller allocation time per individual resource. Note, however, that, in case of
-// a non fully-populated segment, more resources than actually needed are committed.
-// - a smaller segment size leads to a more scattered data structure and more memory allocation
-// calls, but certainly reduces redundancy in memory allocation.
-
-// Iterators to this data structure are smart enough to skip the invalid elements and jump from one
-// segment to the next one, once the end of a segment has been reached.
-
-// The {SegmentedContainer} data structure is meant to closely collaborate with a {SharedPointer}
-// class, which provides the information of resources being unused and therefore redundant. However,
-// the {SharedPointer} class differs from the {shared_ptr} offered by the C++ standard library in
-// two respects:
-//      1) the {SharedPointer} does not have ownership of the resource and does not have privileges
-//          to allocate and deallocate memory for it. In fact, the allocation and deallocation of
-//          memory is entirely managed by the {SegmentedContainer} class, which allocates and
-//          deallocates resources collectively to optimize memory allocation/deallocation. In this
-//          respect, the role of the {SharedPointer} is only that of managing the book keeping on
-//          the count of references to the resources.
-//      2) the {SharedPointer} does not store the reference count directly, but manages a reference
-//          count stored by the resource. The reason for this is that, in order not to compromise
-//          the correctness of the reference count, the {SegmentedContainer} should only make the
-//          resource available to its clients via a {SharedPointer}, which knows how to do the
-//          relative book keeping. Because the reference count is stored directly within the
-//          resource, the {SegmentedContainer} does not need to store a {SharedPointer} to each of
-//          its resources but is able to synthesize a {SharedPointer} on the fly, upon request of
-//          a given resource by a given client.
-
-// The only requirement of the {SegmentedContainer} on the template type {T} of the resources stored
-// is simply that the resource is a {ReferenceCountedObject}, which means that the resource is able
-// to provide the machinery needed by the {SharedPointer} to do the book keeping. Specifically, this
-// translates into the class of the resource inheriting from class {Shareable}, which provides the
-// minimal interface necessary to collaborate with {SharedPointer} to perform reference counting.
-// Ideally, the resource is otherwise immutable (i.e. except from the reference count attribute).
-// The use of {SegmentedContainer} for a class that is not immutable can be envisioned but has not
-// been explored so far.
+// The current implementation only supports immutable resources (i.e. resources can be created
+// and destroyed but cannot be modified once they are into the segmented container). The use of
+// {SegmentedContainer} with a resource type {T} that is not immutable can be envisioned but has
+// not been explored so far.
+//
+// Iterators to a {SegmentedContainer} are smart enough to jump from one segment to the next one,
+// once the end of a segment has been reached.
 
 namespace mito::utilities {
     template <class resourceT>

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -245,9 +245,6 @@ namespace mito::utilities {
          */
         constexpr auto begin() const -> iterator
         {
-            // check that the container is not empty
-            assert(_n_elements > 0);
-
             // get an iterator to the first element
             return iterator(
                 _begin /* ptr */, _begin + _segment_size /* segment_end */, _segment_size,

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -245,6 +245,9 @@ namespace mito::utilities {
          */
         constexpr auto begin() -> iterator
         {
+            // check that the container is not empty
+            assert(_n_elements > 0);
+
             // get an iterator to the first element
             auto it = iterator(
                 _begin /* ptr */, _begin + _segment_size /* segment_end */, _end /* end */, *this);
@@ -264,6 +267,9 @@ namespace mito::utilities {
 
         constexpr auto begin() const -> const_iterator
         {
+            // check that the container is not empty
+            assert(_n_elements > 0);
+
             // get an iterator to the first element
             auto it = const_iterator(
                 _begin /* ptr */, _begin + _segment_size /* segment_end */, _end /* end */, *this);

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -66,20 +66,14 @@
 // been explored so far.
 
 namespace mito::utilities {
-    template <class sharedResourceT>
-    // requires ReferenceCountedObject<sharedResourceT::resource_type>
+    template <class resourceT>
     class SegmentedContainer {
       public:
         // me
-        using segmented_container_type = SegmentedContainer<sharedResourceT>;
+        using segmented_container_type = SegmentedContainer<resourceT>;
 
-        // aliases for my shared pointer type
-        using shared_ptr_type = sharedResourceT;
-        // and my (cv qualified) resource type
-        using resource_type = typename sharedResourceT::resource_type;
-        // and my (cv qualified) handle type
-        using handle_type = typename sharedResourceT::handle_type;
-
+        // my template parameter
+        using resource_type = resourceT;
         // unqualified resource type (for internal book-keeping)
         using unqualified_resource_type = typename std::remove_const<resource_type>::type;
         // raw pointer type to unqualified resource type
@@ -93,8 +87,9 @@ namespace mito::utilities {
 
         // iterators
         using iterator = SegmentedContainerIterator<segmented_container_type>;
+        using iterator_const_reference = const iterator &;
 
-      private:
+      public:
         // default constructor (empty data structure)
         SegmentedContainer(int segment_size) :
             _segment_size(segment_size),
@@ -201,7 +196,8 @@ namespace mito::utilities {
             return _end;
         }
 
-        auto _location_for_placement() -> pointer
+      public:
+        auto location_for_placement() -> pointer
         {
             // fetch the next available location where to write the new element
             auto location = _next_available_location();
@@ -231,7 +227,7 @@ namespace mito::utilities {
         // erase an element from the container
         // (decrement the number of elements and add the address of the element to the pile of the
         // available locations for reuse)
-        auto erase(handle_type element) -> void
+        auto erase(resource_type * element) -> void
         {
             // decrement the number of elements
             --_n_elements;
@@ -302,8 +298,6 @@ namespace mito::utilities {
       private:
         // non-const iterator
         friend iterator;
-        // the repository
-        friend Repository<sharedResourceT>;
     };
 }
 

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -229,6 +229,9 @@ namespace mito::utilities {
         // available locations for reuse)
         auto erase(resource_type * element) -> void
         {
+            // assert that the element to be erased is invalid
+            assert(!element->is_valid());
+
             // decrement the number of elements
             --_n_elements;
 

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -75,7 +75,9 @@ namespace mito::utilities {
         using segmented_container_type = SegmentedContainer<sharedResourceT>;
 
         // aliases for my resource type
-        using resource_type = typename sharedResourceT::resource_t;
+        using resource_type =
+            typename std::remove_const<typename sharedResourceT::resource_t>::type;
+        using handle_type = typename sharedResourceT::handle_t;
 
         // my value
         using pointer = resource_type *;
@@ -225,13 +227,13 @@ namespace mito::utilities {
         // erase an element from the container
         // (decrement the number of elements and add the address of the element to the pile of the
         // available locations for reuse)
-        auto erase(pointer element) -> void
+        auto erase(handle_type element) -> void
         {
             // decrement the number of elements
             --_n_elements;
 
             // add the address of the element to the queue of the available locations for write
-            _available_locations.push(element);
+            _available_locations.push(const_cast<resource_type *>(element));
 
             // all done
             return;

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -139,16 +139,6 @@ namespace mito::utilities {
 
         inline auto segment_size() const noexcept -> int { return _segment_size; }
 
-        // QUESTION: should this be const?
-        // TOFIX: remove this method
-        auto resource(index_t<T> index) -> shared_ptr<T>
-        {
-            // fetch the resource based on the index
-            auto resource = utilities::shared_ptr<T>::resource(index);
-            // wrap the resource in a shared pointer
-            return utilities::shared_ptr<T>(resource);
-        }
-
       private:
         auto _allocate_new_segment() -> T *
         {

--- a/lib/mito/utilities/SegmentedContainerIterator.h
+++ b/lib/mito/utilities/SegmentedContainerIterator.h
@@ -19,8 +19,8 @@ namespace mito::utilities {
         using iterator = SegmentedContainerIterator<segmented_container_type>;
         using iterator_reference = iterator &;
         // what I point to
-        using pointer = typename SegmentedContainerT::const_pointer;
-        using reference = typename SegmentedContainerT::const_reference;
+        using pointer = typename SegmentedContainerT::pointer;
+        using reference = typename SegmentedContainerT::reference;
 
         // metamethods
       public:

--- a/lib/mito/utilities/SegmentedContainerIterator.h
+++ b/lib/mito/utilities/SegmentedContainerIterator.h
@@ -20,6 +20,7 @@ namespace mito::utilities {
         using iterator_reference = iterator &;
         // what I point to
         using pointer = typename SegmentedContainerT::const_pointer;
+        using reference = typename SegmentedContainerT::const_reference;
 
         // metamethods
       public:
@@ -35,11 +36,10 @@ namespace mito::utilities {
         // iterator protocol
       public:
         // dereference
-        // TOFIX: should be const reference
-        constexpr auto operator*() const -> pointer
+        constexpr auto operator*() const -> reference
         {
             // easy enough
-            return ptr();
+            return *_ptr;
         }
 
         // accessors

--- a/lib/mito/utilities/SegmentedContainerIterator.h
+++ b/lib/mito/utilities/SegmentedContainerIterator.h
@@ -60,7 +60,7 @@ namespace mito::utilities {
         constexpr auto operator*() const -> shared_pointer
         {
             // wrap the resource in a shared pointer and return it
-            return shared_pointer(_ptr, &_container);
+            return shared_pointer(_ptr);
         }
 
         // accessors

--- a/lib/mito/utilities/SegmentedContainerIterator.h
+++ b/lib/mito/utilities/SegmentedContainerIterator.h
@@ -46,12 +46,11 @@ namespace mito::utilities {
       public:
         // constructor
         constexpr SegmentedContainerIterator(
-            pointer ptr, pointer segment_end, pointer end,
-            segmented_container_reference container) :
+            pointer ptr, pointer segment_end, int segment_size, pointer end) :
             _ptr(ptr),
             _segment_end(segment_end),
-            _end(end),
-            _container(container)
+            _segment_size(segment_size),
+            _end(end)
         {}
 
         // iterator protocol
@@ -93,7 +92,7 @@ namespace mito::utilities {
                     // by the segmented container right at the end of the current segment
                     _ptr = *(reinterpret_cast<const pointer *>(_ptr));
                     // store the start of the current segment
-                    _segment_end = _ptr + _container.segment_size();
+                    _segment_end = _ptr + _segment_size;
                 }
 
                 // if the element is valid
@@ -127,17 +126,12 @@ namespace mito::utilities {
         pointer _ptr;
         // pointer to the end of the current segment
         pointer _segment_end;
+        // the size of a segment
+        const int _segment_size;
         // pointer to the end of the segmented container
         // (this is necessary as the end of the container may not coincide with the end of the
         // allocated memory)
         pointer _end;
-        // TOFIX: Iterators should not need to have a reference to the container that they are
-        //  iterating on. However, this is necessary if we want to be able to hand to the shared
-        //  pointers a pointer to the container that owns the memory of the resource
-        //  Also, this reference cannot be const because the shared pointer might need to erase the
-        //  element in the destructor.
-        // a reference to the segmented container
-        segmented_container_reference _container;
 
         // default metamethods
       public:

--- a/lib/mito/utilities/SegmentedContainerIterator.h
+++ b/lib/mito/utilities/SegmentedContainerIterator.h
@@ -8,39 +8,20 @@
 
 
 namespace mito::utilities {
-    // polymorphic base class for building iterators
-    template <class containerT, bool isConst>
-    class iterator_base {
-      public:
-        using iterator_category = std::forward_iterator_tag;
-        using pointer = std::conditional_t<
-            isConst, typename containerT::const_pointer, typename containerT::pointer>;
-        using reference = std::conditional_t<
-            isConst, typename containerT::const_reference, typename containerT::reference>;
-    };
 
-    template <class SegmentedContainerT, bool isConst>
-    class SegmentedContainerIterator : public iterator_base<SegmentedContainerT, isConst> {
+    template <class SegmentedContainerT>
+    class SegmentedContainerIterator {
         // types
       public:
         // my template parameters
         using segmented_container_type = SegmentedContainerT;
-        using segmented_container_resource_type = typename SegmentedContainerT::resource_type;
         // me
-        using iterator = SegmentedContainerIterator<segmented_container_type, isConst>;
+        using iterator = SegmentedContainerIterator<segmented_container_type>;
         using iterator_reference = iterator &;
-        // my base class
-        using iterbase = iterator_base<segmented_container_type, isConst>;
-        // my parts
-        using segmented_container_reference = std::conditional_t<
-            isConst, const segmented_container_type &, segmented_container_type &>;
-        using segmented_container_const_reference = const segmented_container_type &;
-        // what i point to
-        using pointer = typename iterbase::pointer;
-        using shared_pointer = std::conditional_t<
-            isConst, shared_ptr<const segmented_container_resource_type>,
-            shared_ptr<segmented_container_resource_type>>;
-        using reference = typename iterbase::reference;
+        // what I point to
+        using pointer = typename SegmentedContainerT::pointer;
+        // what I hand out
+        using shared_pointer = typename segmented_container_type::shared_ptr_type;
 
         // metamethods
       public:
@@ -148,20 +129,20 @@ namespace mito::utilities {
 
     // the global operators
     // equality
-    template <class SegmentedContainerT, bool isConst>
+    template <class SegmentedContainerT>
     constexpr auto operator==(
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) noexcept -> bool
+        const SegmentedContainerIterator<SegmentedContainerT> & it1,
+        const SegmentedContainerIterator<SegmentedContainerT> & it2) noexcept -> bool
     {
         // iterators are equal if they point to the same segmented container
         return it1.ptr() == it2.ptr();
     }
 
     // and not
-    template <class SegmentedContainerT, bool isConst>
+    template <class SegmentedContainerT>
     constexpr auto operator!=(
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) noexcept -> bool
+        const SegmentedContainerIterator<SegmentedContainerT> & it1,
+        const SegmentedContainerIterator<SegmentedContainerT> & it2) noexcept -> bool
     {
         // iterators are unequal iff they are not equal
         return !(it1 == it2);

--- a/lib/mito/utilities/SegmentedContainerIterator.h
+++ b/lib/mito/utilities/SegmentedContainerIterator.h
@@ -19,9 +19,7 @@ namespace mito::utilities {
         using iterator = SegmentedContainerIterator<segmented_container_type>;
         using iterator_reference = iterator &;
         // what I point to
-        using pointer = typename SegmentedContainerT::pointer;
-        // what I hand out
-        using shared_pointer = typename segmented_container_type::shared_ptr_type;
+        using pointer = typename SegmentedContainerT::const_pointer;
 
         // metamethods
       public:
@@ -37,10 +35,11 @@ namespace mito::utilities {
         // iterator protocol
       public:
         // dereference
-        constexpr auto operator*() const -> shared_pointer
+        // TOFIX: should be const reference
+        constexpr auto operator*() const -> pointer
         {
-            // wrap the resource in a shared pointer and return it
-            return shared_pointer(_ptr);
+            // easy enough
+            return ptr();
         }
 
         // accessors

--- a/lib/mito/utilities/SegmentedContainerIterator.h
+++ b/lib/mito/utilities/SegmentedContainerIterator.h
@@ -49,6 +49,13 @@ namespace mito::utilities {
             return _ptr;
         }
 
+        // accessors
+        constexpr auto end() const noexcept -> pointer
+        {
+            // easy enough
+            return _end;
+        }
+
         // operator->
         constexpr auto operator->() const noexcept -> pointer
         {
@@ -59,31 +66,23 @@ namespace mito::utilities {
         // arithmetic: prefix
         constexpr auto operator++() -> iterator_reference
         {
-            // if not at the end of the segment
-            while (++_ptr) {
-                // end of the container
-                if (_ptr == _end) {
-                    return *this;
-                }
+            // move on to the next item
+            ++_ptr;
 
-                // end of the segment
-                if (_ptr == _segment_end) {
-                    // retrieve the location of the next segment which is left behind
-                    // by the segmented container right at the end of the current segment
-                    _ptr = *(reinterpret_cast<const pointer *>(_ptr));
-                    // store the start of the current segment
-                    _segment_end = _ptr + _segment_size;
-                }
-
-                // if the element is valid
-                if (_ptr->is_valid()) {
-                    // found it
-                    return *this;
-                }
+            // if you reached the end of the container
+            if (_ptr == _end) {
+                // return the end
+                return *this;
             }
 
-            // you should never end up here
-            assert(false);
+            // if you reached the end of the segment
+            if (_ptr == _segment_end) {
+                // retrieve the location of the next segment (which is left behind
+                // by the segmented container right at the end of the current segment)
+                _ptr = *(reinterpret_cast<const pointer *>(_ptr));
+                // take note of the end of the next segment
+                _segment_end = _ptr + _segment_size;
+            }
 
             // all done
             return *this;

--- a/lib/mito/utilities/SharedPointer.h
+++ b/lib/mito/utilities/SharedPointer.h
@@ -27,9 +27,6 @@ namespace mito::utilities {
         // accessor for the number of outstanding references
         inline auto references() const -> int;
 
-        // reset the shared pointer
-        inline auto reset() -> void;
-
         // check if the handle is the null pointer
         inline auto is_nullptr() const noexcept -> bool;
 
@@ -69,6 +66,9 @@ namespace mito::utilities {
         // returns the resource corresponding to this resource id
         static inline auto resource(index_t<Resource>) -> handle_t;
 
+        // reset the shared pointer
+        inline auto reset() -> void;
+
         // increment the reference count
         inline auto _acquire() const -> void;
         // decrement the reference count
@@ -80,8 +80,8 @@ namespace mito::utilities {
         handle_t _handle;
 
       private:
-        // friendship with SegmentedContainer
-        friend class utilities::SegmentedContainer<resource_t>;
+        // friendship with Repository
+        friend class utilities::Repository<resource_t>;
     };
 
     template <class Resource>

--- a/lib/mito/utilities/SharedPointer.h
+++ b/lib/mito/utilities/SharedPointer.h
@@ -81,7 +81,7 @@ namespace mito::utilities {
 
       private:
         // friendship with Repository
-        friend class utilities::Repository<resource_t>;
+        friend class Repository<shared_ptr_t>;
     };
 
     template <class Resource>

--- a/lib/mito/utilities/SharedPointer.h
+++ b/lib/mito/utilities/SharedPointer.h
@@ -15,14 +15,14 @@ namespace mito::utilities {
     class SharedPointer {
         // types
       public:
-        using shared_ptr_t = SharedPointer<resourceT>;
-        using resource_t = resourceT;
-        using handle_t = resourceT *;
+        using shared_ptr_type = SharedPointer<resourceT>;
+        using resource_type = resourceT;
+        using handle_type = resourceT *;
 
         // interface
       public:
         // returns the id of this (oriented) simplex
-        inline auto id() const -> index_t<resource_t>;
+        inline auto id() const -> index_t<resource_type>;
 
         // accessor for the number of outstanding references
         inline auto references() const -> int;
@@ -31,10 +31,10 @@ namespace mito::utilities {
         inline auto is_nullptr() const noexcept -> bool;
 
         // operator->
-        auto operator->() const noexcept -> handle_t;
+        auto operator->() const noexcept -> handle_type;
 
         // // operator*
-        // auto operator*() const -> const resource_t &;
+        // auto operator*() const -> const resource_type &;
 
         // meta methods
       public:
@@ -45,26 +45,26 @@ namespace mito::utilities {
         inline SharedPointer();
 
         // constructor
-        inline SharedPointer(handle_t);
+        inline SharedPointer(handle_type);
 
         // copy constructor
-        inline SharedPointer(const shared_ptr_t &);
+        inline SharedPointer(const shared_ptr_type &);
 
         // move constructor
-        inline SharedPointer(shared_ptr_t &&) noexcept;
+        inline SharedPointer(shared_ptr_type &&) noexcept;
 
         // assignment operator
-        inline shared_ptr_t & operator=(const shared_ptr_t &);
+        inline shared_ptr_type & operator=(const shared_ptr_type &);
 
         // move assignment operator
-        inline shared_ptr_t & operator=(shared_ptr_t &&);
+        inline shared_ptr_type & operator=(shared_ptr_type &&);
 
       private:
         // accessor for {handle}
-        inline auto handle() const noexcept -> handle_t;
+        inline auto handle() const noexcept -> handle_type;
 
         // returns the resource corresponding to this resource id
-        static inline auto resource(index_t<resource_t>) -> handle_t;
+        static inline auto resource(index_t<resource_type>) -> handle_type;
 
         // reset the shared pointer
         inline auto reset() -> void;
@@ -77,11 +77,11 @@ namespace mito::utilities {
         // data members
       private:
         // handle to the resource
-        handle_t _handle;
+        handle_type _handle;
 
       private:
         // friendship with Repository
-        friend class Repository<shared_ptr_t>;
+        friend class Repository<shared_ptr_type>;
     };
 
     template <class resourceT>

--- a/lib/mito/utilities/SharedPointer.h
+++ b/lib/mito/utilities/SharedPointer.h
@@ -10,19 +10,19 @@
 namespace mito::utilities {
 
     // declaration
-    template <class Resource>
-    // requires ReferenceCountedObject<Resource>
+    template <class resourceT>
+    // requires ReferenceCountedObject<resourceT>
     class SharedPointer {
         // types
       public:
-        using shared_ptr_t = SharedPointer<Resource>;
-        using resource_t = Resource;
-        using handle_t = Resource *;
+        using shared_ptr_t = SharedPointer<resourceT>;
+        using resource_t = resourceT;
+        using handle_t = resourceT *;
 
         // interface
       public:
         // returns the id of this (oriented) simplex
-        inline auto id() const -> index_t<Resource>;
+        inline auto id() const -> index_t<resource_t>;
 
         // accessor for the number of outstanding references
         inline auto references() const -> int;
@@ -48,23 +48,23 @@ namespace mito::utilities {
         inline SharedPointer(handle_t);
 
         // copy constructor
-        inline SharedPointer(const SharedPointer<Resource> &);
+        inline SharedPointer(const shared_ptr_t &);
 
         // move constructor
-        inline SharedPointer(SharedPointer<Resource> &&) noexcept;
+        inline SharedPointer(shared_ptr_t &&) noexcept;
 
         // assignment operator
-        inline SharedPointer & operator=(const SharedPointer<Resource> &);
+        inline shared_ptr_t & operator=(const shared_ptr_t &);
 
         // move assignment operator
-        inline SharedPointer & operator=(SharedPointer<Resource> &&);
+        inline shared_ptr_t & operator=(shared_ptr_t &&);
 
       private:
         // accessor for {handle}
         inline auto handle() const noexcept -> handle_t;
 
         // returns the resource corresponding to this resource id
-        static inline auto resource(index_t<Resource>) -> handle_t;
+        static inline auto resource(index_t<resource_t>) -> handle_t;
 
         // reset the shared pointer
         inline auto reset() -> void;
@@ -84,14 +84,16 @@ namespace mito::utilities {
         friend class Repository<shared_ptr_t>;
     };
 
-    template <class Resource>
-    inline bool operator==(const SharedPointer<Resource> & lhs, const SharedPointer<Resource> & rhs)
+    template <class resourceT>
+    inline bool operator==(
+        const SharedPointer<resourceT> & lhs, const SharedPointer<resourceT> & rhs)
     {
         return lhs.id() == rhs.id();
     }
 
-    template <class Resource>
-    inline bool operator<(const SharedPointer<Resource> & lhs, const SharedPointer<Resource> & rhs)
+    template <class resourceT>
+    inline bool operator<(
+        const SharedPointer<resourceT> & lhs, const SharedPointer<resourceT> & rhs)
     {
         return lhs.id() < rhs.id();
     }

--- a/lib/mito/utilities/SharedPointer.h
+++ b/lib/mito/utilities/SharedPointer.h
@@ -48,7 +48,7 @@ namespace mito::utilities {
         inline SharedPointer();
 
         // constructor
-        inline SharedPointer(handle_t, segmented_t<shared_ptr_t> *);
+        inline SharedPointer(handle_t);
 
         // copy constructor
         inline SharedPointer(const SharedPointer<Resource> &);
@@ -78,8 +78,6 @@ namespace mito::utilities {
       private:
         // handle to the resource
         handle_t _handle;
-        // reference to the segmented container, which owns the memory
-        segmented_t<shared_ptr_t> * _container;
 
       private:
         // friendship with SegmentedContainer

--- a/lib/mito/utilities/SharedPointer.icc
+++ b/lib/mito/utilities/SharedPointer.icc
@@ -201,7 +201,7 @@ mito::utilities::SharedPointer<Resource>::_release() const -> void
         if (reference_count == 0 && _container != nullptr) {
             // erase it from the container (decrement the number of elements and add the address of
             // the element to the queue of the available locations for reuse)
-            return _container->erase(*this);
+            // return _container->erase(*this);
         }
 
         // all done

--- a/lib/mito/utilities/SharedPointer.icc
+++ b/lib/mito/utilities/SharedPointer.icc
@@ -156,7 +156,6 @@ mito::utilities::SharedPointer<resourceT>::operator=(
         _handle = other._handle;
     }
 
-    // QUESTION: should this go here or in the if statement?
     // invalidate {other}
     other._handle = nullptr;
 

--- a/lib/mito/utilities/SharedPointer.icc
+++ b/lib/mito/utilities/SharedPointer.icc
@@ -15,17 +15,17 @@ mito::utilities::SharedPointer<resourceT>::id() const -> index_t<resourceT>
 
 template <class resourceT>
 auto
-mito::utilities::SharedPointer<resourceT>::resource(index_t<resourceT> index) -> handle_t
+mito::utilities::SharedPointer<resourceT>::resource(index_t<resourceT> index) -> handle_type
 {
     // the id is the (immutable) address of this object
-    return reinterpret_cast<handle_t>(index);
+    return reinterpret_cast<handle_type>(index);
 }
 
 // interface
 template <class resourceT>
 auto
 mito::utilities::SharedPointer<resourceT>::handle() const noexcept
-    -> mito::utilities::SharedPointer<resourceT>::handle_t
+    -> mito::utilities::SharedPointer<resourceT>::handle_type
 {
     // return the handle
     return _handle;
@@ -65,7 +65,7 @@ mito::utilities::SharedPointer<resourceT>::is_nullptr() const noexcept -> bool
 template <class resourceT>
 auto
 mito::utilities::SharedPointer<resourceT>::operator->() const noexcept
-    -> mito::utilities::SharedPointer<resourceT>::handle_t
+    -> mito::utilities::SharedPointer<resourceT>::handle_type
 {
     // return the handle
     return _handle;
@@ -75,7 +75,7 @@ mito::utilities::SharedPointer<resourceT>::operator->() const noexcept
 // template <class resourceT>
 // auto
 // mito::utilities::SharedPointer<resourceT>::operator*() const
-//     -> const mito::utilities::SharedPointer<resourceT>::resource_t &
+//     -> const mito::utilities::SharedPointer<resourceT>resource_type &
 // {
 //     // return the resource
 //     return *_handle;
@@ -96,7 +96,7 @@ mito::utilities::SharedPointer<resourceT>::SharedPointer() : _handle(nullptr)
 
 // the constructor
 template <class resourceT>
-mito::utilities::SharedPointer<resourceT>::SharedPointer(handle_t resource) : _handle(resource)
+mito::utilities::SharedPointer<resourceT>::SharedPointer(handle_type resource) : _handle(resource)
 {
     // grab a reference to the shared handle
     _acquire();

--- a/lib/mito/utilities/SharedPointer.icc
+++ b/lib/mito/utilities/SharedPointer.icc
@@ -5,43 +5,43 @@
 #error This header file contains implementation details of class mito::utilities::SharedPointer
 #else
 
-template <class Resource>
+template <class resourceT>
 auto
-mito::utilities::SharedPointer<Resource>::id() const -> index_t<Resource>
+mito::utilities::SharedPointer<resourceT>::id() const -> index_t<resourceT>
 {
     // the id is the (immutable) address of this object
-    return reinterpret_cast<index_t<Resource>>(_handle);
+    return reinterpret_cast<index_t<resourceT>>(_handle);
 }
 
-template <class Resource>
+template <class resourceT>
 auto
-mito::utilities::SharedPointer<Resource>::resource(index_t<Resource> index) -> handle_t
+mito::utilities::SharedPointer<resourceT>::resource(index_t<resourceT> index) -> handle_t
 {
     // the id is the (immutable) address of this object
     return reinterpret_cast<handle_t>(index);
 }
 
 // interface
-template <class Resource>
+template <class resourceT>
 auto
-mito::utilities::SharedPointer<Resource>::handle() const noexcept
-    -> mito::utilities::SharedPointer<Resource>::handle_t
+mito::utilities::SharedPointer<resourceT>::handle() const noexcept
+    -> mito::utilities::SharedPointer<resourceT>::handle_t
 {
     // return the handle
     return _handle;
 }
 
-template <class Resource>
+template <class resourceT>
 auto
-mito::utilities::SharedPointer<Resource>::references() const -> int
+mito::utilities::SharedPointer<resourceT>::references() const -> int
 {
     // return the count of outstanding references
     return _handle->_references();
 }
 
-template <class Resource>
+template <class resourceT>
 auto
-mito::utilities::SharedPointer<Resource>::reset() -> void
+mito::utilities::SharedPointer<resourceT>::reset() -> void
 {
     // release my current handle
     _release();
@@ -53,59 +53,59 @@ mito::utilities::SharedPointer<Resource>::reset() -> void
     return;
 }
 
-template <class Resource>
+template <class resourceT>
 auto
-mito::utilities::SharedPointer<Resource>::is_nullptr() const noexcept -> bool
+mito::utilities::SharedPointer<resourceT>::is_nullptr() const noexcept -> bool
 {
     // all done
     return _handle == nullptr;
 }
 
 // operator->
-template <class Resource>
+template <class resourceT>
 auto
-mito::utilities::SharedPointer<Resource>::operator->() const noexcept
-    -> mito::utilities::SharedPointer<Resource>::handle_t
+mito::utilities::SharedPointer<resourceT>::operator->() const noexcept
+    -> mito::utilities::SharedPointer<resourceT>::handle_t
 {
     // return the handle
     return _handle;
 }
 
 // // operator*
-// template <class Resource>
+// template <class resourceT>
 // auto
-// mito::utilities::SharedPointer<Resource>::operator*() const
-//     -> const mito::utilities::SharedPointer<Resource>::resource_t &
+// mito::utilities::SharedPointer<resourceT>::operator*() const
+//     -> const mito::utilities::SharedPointer<resourceT>::resource_t &
 // {
 //     // return the resource
 //     return *_handle;
 // }
 
 // destructor
-template <class Resource>
-mito::utilities::SharedPointer<Resource>::~SharedPointer()
+template <class resourceT>
+mito::utilities::SharedPointer<resourceT>::~SharedPointer()
 {
     // release my current handle
     _release();
 }
 
 // default constructor (invalid shared handle)
-template <class Resource>
-mito::utilities::SharedPointer<Resource>::SharedPointer() : _handle(nullptr)
+template <class resourceT>
+mito::utilities::SharedPointer<resourceT>::SharedPointer() : _handle(nullptr)
 {}
 
 // the constructor
-template <class Resource>
-mito::utilities::SharedPointer<Resource>::SharedPointer(handle_t resource) : _handle(resource)
+template <class resourceT>
+mito::utilities::SharedPointer<resourceT>::SharedPointer(handle_t resource) : _handle(resource)
 {
     // grab a reference to the shared handle
     _acquire();
 }
 
 // the copy constructor
-template <class Resource>
-mito::utilities::SharedPointer<Resource>::SharedPointer(
-    const mito::utilities::SharedPointer<Resource> & other) :
+template <class resourceT>
+mito::utilities::SharedPointer<resourceT>::SharedPointer(
+    const mito::utilities::SharedPointer<resourceT> & other) :
     _handle(other._handle)
 {
     // grab a reference to the shared handle
@@ -113,9 +113,9 @@ mito::utilities::SharedPointer<Resource>::SharedPointer(
 }
 
 // the move constructor
-template <class Resource>
-mito::utilities::SharedPointer<Resource>::SharedPointer(
-    mito::utilities::SharedPointer<Resource> && other) noexcept :
+template <class resourceT>
+mito::utilities::SharedPointer<resourceT>::SharedPointer(
+    mito::utilities::SharedPointer<resourceT> && other) noexcept :
     _handle(other._handle)
 {
     // invalidate other
@@ -123,10 +123,10 @@ mito::utilities::SharedPointer<Resource>::SharedPointer(
 }
 
 // assignment operator
-template <class Resource>
-mito::utilities::SharedPointer<Resource> &
-mito::utilities::SharedPointer<Resource>::operator=(
-    const mito::utilities::SharedPointer<Resource> & other)
+template <class resourceT>
+mito::utilities::SharedPointer<resourceT> &
+mito::utilities::SharedPointer<resourceT>::operator=(
+    const mito::utilities::SharedPointer<resourceT> & other)
 {
     // if {other} and I point to different handles
     if (other._handle != _handle) {
@@ -143,10 +143,10 @@ mito::utilities::SharedPointer<Resource>::operator=(
 }
 
 // move assignment operator
-template <class Resource>
-mito::utilities::SharedPointer<Resource> &
-mito::utilities::SharedPointer<Resource>::operator=(
-    mito::utilities::SharedPointer<Resource> && other)
+template <class resourceT>
+mito::utilities::SharedPointer<resourceT> &
+mito::utilities::SharedPointer<resourceT>::operator=(
+    mito::utilities::SharedPointer<resourceT> && other)
 {
     // if {other} and I point to different handles
     if (other._handle != _handle) {
@@ -165,9 +165,9 @@ mito::utilities::SharedPointer<Resource>::operator=(
 }
 
 // interface
-template <class Resource>
+template <class resourceT>
 auto
-mito::utilities::SharedPointer<Resource>::_acquire() const -> void
+mito::utilities::SharedPointer<resourceT>::_acquire() const -> void
 {
     // acquire resource (increment reference count)
     _handle->_acquire();
@@ -175,9 +175,9 @@ mito::utilities::SharedPointer<Resource>::_acquire() const -> void
     return;
 }
 
-template <class Resource>
+template <class resourceT>
 auto
-mito::utilities::SharedPointer<Resource>::_release() const -> void
+mito::utilities::SharedPointer<resourceT>::_release() const -> void
 {
     // if the handle is in valid state
     if (_handle != nullptr) {

--- a/lib/mito/utilities/SharedPointer.icc
+++ b/lib/mito/utilities/SharedPointer.icc
@@ -49,9 +49,6 @@ mito::utilities::SharedPointer<Resource>::reset() -> void
     // invalidate handle to the resource
     _handle = nullptr;
 
-    // invalidate handle to the segmented container
-    _container = nullptr;
-
     // all done
     return;
 }
@@ -94,15 +91,12 @@ mito::utilities::SharedPointer<Resource>::~SharedPointer()
 
 // default constructor (invalid shared handle)
 template <class Resource>
-mito::utilities::SharedPointer<Resource>::SharedPointer() : _handle(nullptr), _container(nullptr)
+mito::utilities::SharedPointer<Resource>::SharedPointer() : _handle(nullptr)
 {}
 
 // the constructor
 template <class Resource>
-mito::utilities::SharedPointer<Resource>::SharedPointer(
-    handle_t resource, segmented_t<shared_ptr_t> * container) :
-    _handle(resource),
-    _container(container)
+mito::utilities::SharedPointer<Resource>::SharedPointer(handle_t resource) : _handle(resource)
 {
     // grab a reference to the shared handle
     _acquire();
@@ -112,8 +106,7 @@ mito::utilities::SharedPointer<Resource>::SharedPointer(
 template <class Resource>
 mito::utilities::SharedPointer<Resource>::SharedPointer(
     const mito::utilities::SharedPointer<Resource> & other) :
-    _handle(other._handle),
-    _container(other._container)
+    _handle(other._handle)
 {
     // grab a reference to the shared handle
     _acquire();
@@ -123,12 +116,10 @@ mito::utilities::SharedPointer<Resource>::SharedPointer(
 template <class Resource>
 mito::utilities::SharedPointer<Resource>::SharedPointer(
     mito::utilities::SharedPointer<Resource> && other) noexcept :
-    _handle(other._handle),
-    _container(other._container)
+    _handle(other._handle)
 {
     // invalidate other
     other._handle = nullptr;
-    other._container = nullptr;
 }
 
 // assignment operator
@@ -145,8 +136,6 @@ mito::utilities::SharedPointer<Resource>::operator=(
         _handle = other._handle;
         // and grab a reference to it
         _acquire();
-        // grab the container handle
-        _container = other._container;
     }
 
     // all done
@@ -165,14 +154,11 @@ mito::utilities::SharedPointer<Resource>::operator=(
         _release();
         // adopt the new shareable
         _handle = other._handle;
-        // grab the container handle
-        _container = other._container;
     }
 
     // QUESTION: should this go here or in the if statement?
     // invalidate {other}
     other._handle = nullptr;
-    other._container = nullptr;
 
     // all done
     return *this;
@@ -196,13 +182,7 @@ mito::utilities::SharedPointer<Resource>::_release() const -> void
     // if the handle is in valid state
     if (_handle != nullptr) {
         // release my current handle (decreases reference count by one)
-        const auto reference_count = _handle->_release();
-        // if the resource is now unused
-        if (reference_count == 0 && _container != nullptr) {
-            // erase it from the container (decrement the number of elements and add the address of
-            // the element to the queue of the available locations for reuse)
-            // return _container->erase(*this);
-        }
+        _handle->_release();
 
         // all done
         return;

--- a/lib/mito/utilities/api.h
+++ b/lib/mito/utilities/api.h
@@ -5,10 +5,12 @@
 
 namespace mito::utilities {
 
+    // TOFIX: uniform notation Resource, ResourceT, resourceT, ...
     // shared pointer alias
     template <class Resource>
     using shared_ptr = SharedPointer<Resource>;
 
+    // TOFIX: perhaps eventually remove indices?
     // index type alias
     template <class Resource>
     using index_t = std::uintptr_t;
@@ -16,6 +18,11 @@ namespace mito::utilities {
     // segmented container alias
     template <class T>
     using segmented_t = SegmentedContainer<typename T::resource_t>;
+
+    // the repository
+    template <class resourceT>
+    using repository_t = class Repository<resourceT>;
+
 }
 
 

--- a/lib/mito/utilities/api.h
+++ b/lib/mito/utilities/api.h
@@ -15,8 +15,8 @@ namespace mito::utilities {
     using index_t = std::uintptr_t;
 
     // segmented container alias
-    template <class sharedResourceT>
-    using segmented_t = SegmentedContainer<sharedResourceT>;
+    template <class resourceT>
+    using segmented_t = SegmentedContainer<resourceT>;
 
     // the repository
     template <class sharedResourceT>

--- a/lib/mito/utilities/api.h
+++ b/lib/mito/utilities/api.h
@@ -16,13 +16,12 @@ namespace mito::utilities {
     using index_t = std::uintptr_t;
 
     // segmented container alias
-    template <class T>
-    using segmented_t = SegmentedContainer<typename T::resource_t>;
+    template <class sharedResourceT>
+    using segmented_t = SegmentedContainer<sharedResourceT>;
 
     // the repository
-    template <class resourceT>
-    using repository_t = class Repository<resourceT>;
-
+    template <class sharedResourceT>
+    using repository_t = class Repository<sharedResourceT>;
 }
 
 

--- a/lib/mito/utilities/api.h
+++ b/lib/mito/utilities/api.h
@@ -5,14 +5,13 @@
 
 namespace mito::utilities {
 
-    // TOFIX: uniform notation Resource, ResourceT, resourceT, ...
     // shared pointer alias
-    template <class Resource>
-    using shared_ptr = SharedPointer<Resource>;
+    template <class resourceT>
+    using shared_ptr = SharedPointer<resourceT>;
 
     // TOFIX: perhaps eventually remove indices?
     // index type alias
-    template <class Resource>
+    template <class resourceT>
     using index_t = std::uintptr_t;
 
     // segmented container alias

--- a/lib/mito/utilities/forward.h
+++ b/lib/mito/utilities/forward.h
@@ -26,6 +26,11 @@ namespace mito::utilities {
     template <class SegmentedContainerT, bool isConst>
     class SegmentedContainerIterator;
 
+    // the repository
+    template <class resourceT>
+    class Repository;
+
+    // TOFIX: move these guys to a {utilities.h} header?
     // segmented container iterator
     // equality
     template <class SegmentedContainerT, bool isConst>

--- a/lib/mito/utilities/forward.h
+++ b/lib/mito/utilities/forward.h
@@ -18,8 +18,7 @@ namespace mito::utilities {
     class SharedPointer;
 
     // class segmented container
-    template <class sharedResourceT>
-    // requires ReferenceCountedObject<typename sharedResourceT::resource_type>
+    template <class resourceT>
     class SegmentedContainer;
 
     // and its iterator
@@ -31,6 +30,9 @@ namespace mito::utilities {
     // requires ReferenceCountedObject<typename sharedResourceT::resource_type>
     class Repository;
 
+    // and its iterator
+    template <class RepositoryT>
+    class RepositoryIterator;
 }
 
 

--- a/lib/mito/utilities/forward.h
+++ b/lib/mito/utilities/forward.h
@@ -31,31 +31,6 @@ namespace mito::utilities {
     // requires ReferenceCountedObject<typename sharedResourceT::resource_type>
     class Repository;
 
-    // TOFIX: move these guys to a {utilities.h} header?
-    // segmented container iterator
-    // equality
-    template <class SegmentedContainerT>
-    constexpr auto operator==(
-        const SegmentedContainerIterator<SegmentedContainerT> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT> & it2) noexcept -> bool;
-
-
-    // and not
-    template <class SegmentedContainerT>
-    constexpr auto operator!=(
-        const SegmentedContainerIterator<SegmentedContainerT> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT> & it2) noexcept -> bool;
-
-    // hash function for shared pointers
-    // Note that two pointers pointing to the same cell collapse on the same hashed value
-    template <class sharedPointerT>
-    struct hash_function {
-        size_t operator()(const sharedPointerT & item) const
-        {
-            // reinterpret the address of the pointed handle as a {size_t} and return it
-            return reinterpret_cast<size_t>(item.id());
-        }
-    };
 }
 
 

--- a/lib/mito/utilities/forward.h
+++ b/lib/mito/utilities/forward.h
@@ -18,8 +18,8 @@ namespace mito::utilities {
     class SharedPointer;
 
     // class segmented container
-    template <class Resource>
-    // requires ReferenceCountedObject<Resource>
+    template <class sharedResourceT>
+    // requires ReferenceCountedObject<typename sharedResourceT::resource_t>
     class SegmentedContainer;
 
     // and its iterator
@@ -27,7 +27,8 @@ namespace mito::utilities {
     class SegmentedContainerIterator;
 
     // the repository
-    template <class resourceT>
+    template <class sharedResourceT>
+    // requires ReferenceCountedObject<typename sharedResourceT::resource_t>
     class Repository;
 
     // TOFIX: move these guys to a {utilities.h} header?

--- a/lib/mito/utilities/forward.h
+++ b/lib/mito/utilities/forward.h
@@ -19,7 +19,7 @@ namespace mito::utilities {
 
     // class segmented container
     template <class sharedResourceT>
-    // requires ReferenceCountedObject<typename sharedResourceT::resource_t>
+    // requires ReferenceCountedObject<typename sharedResourceT::resource_type>
     class SegmentedContainer;
 
     // and its iterator
@@ -28,7 +28,7 @@ namespace mito::utilities {
 
     // the repository
     template <class sharedResourceT>
-    // requires ReferenceCountedObject<typename sharedResourceT::resource_t>
+    // requires ReferenceCountedObject<typename sharedResourceT::resource_type>
     class Repository;
 
     // TOFIX: move these guys to a {utilities.h} header?

--- a/lib/mito/utilities/forward.h
+++ b/lib/mito/utilities/forward.h
@@ -23,7 +23,7 @@ namespace mito::utilities {
     class SegmentedContainer;
 
     // and its iterator
-    template <class SegmentedContainerT, bool isConst>
+    template <class SegmentedContainerT>
     class SegmentedContainerIterator;
 
     // the repository
@@ -34,17 +34,17 @@ namespace mito::utilities {
     // TOFIX: move these guys to a {utilities.h} header?
     // segmented container iterator
     // equality
-    template <class SegmentedContainerT, bool isConst>
+    template <class SegmentedContainerT>
     constexpr auto operator==(
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) noexcept -> bool;
+        const SegmentedContainerIterator<SegmentedContainerT> & it1,
+        const SegmentedContainerIterator<SegmentedContainerT> & it2) noexcept -> bool;
 
 
     // and not
-    template <class SegmentedContainerT, bool isConst>
+    template <class SegmentedContainerT>
     constexpr auto operator!=(
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT, isConst> & it2) noexcept -> bool;
+        const SegmentedContainerIterator<SegmentedContainerT> & it1,
+        const SegmentedContainerIterator<SegmentedContainerT> & it2) noexcept -> bool;
 
     // hash function for shared pointers
     // Note that two pointers pointing to the same cell collapse on the same hashed value

--- a/lib/mito/utilities/forward.h
+++ b/lib/mito/utilities/forward.h
@@ -9,12 +9,12 @@ namespace mito::utilities {
     class Shareable;
 
     // concept for a reference counted object
-    template <typename T>
-    concept ReferenceCountedObject = std::is_base_of<Shareable, T>::value;
+    template <typename resourceT>
+    concept ReferenceCountedObject = std::is_base_of<Shareable, resourceT>::value;
 
     // class shared pointer based on a reference counted resource
-    template <class Resource>
-    // requires ReferenceCountedObject<Resource>
+    template <class resourceT>
+    // requires ReferenceCountedObject<resourceT>
     class SharedPointer;
 
     // class segmented container

--- a/lib/mito/utilities/public.h
+++ b/lib/mito/utilities/public.h
@@ -18,6 +18,7 @@
 #include "SharedPointer.h"
 #include "SegmentedContainer.h"
 #include "SegmentedContainerIterator.h"
+#include "Repository.h"
 
 // factories implementation
 #include "factories.h"

--- a/lib/mito/utilities/public.h
+++ b/lib/mito/utilities/public.h
@@ -23,6 +23,8 @@
 // factories implementation
 #include "factories.h"
 
+// utilities
+#include "utilities.h"
 
 #endif
 

--- a/lib/mito/utilities/public.h
+++ b/lib/mito/utilities/public.h
@@ -19,6 +19,7 @@
 #include "SegmentedContainer.h"
 #include "SegmentedContainerIterator.h"
 #include "Repository.h"
+#include "RepositoryIterator.h"
 
 // factories implementation
 #include "factories.h"

--- a/lib/mito/utilities/utilities.h
+++ b/lib/mito/utilities/utilities.h
@@ -1,0 +1,35 @@
+// code guard
+#if !defined(mito_utilities_utilities_h)
+#define mito_utilities_utilities_h
+
+
+namespace mito::utilities {
+    // segmented container iterator equality
+    template <class SegmentedContainerT>
+    constexpr auto operator==(
+        const SegmentedContainerIterator<SegmentedContainerT> & it1,
+        const SegmentedContainerIterator<SegmentedContainerT> & it2) noexcept -> bool;
+
+
+    // and inequality
+    template <class SegmentedContainerT>
+    constexpr auto operator!=(
+        const SegmentedContainerIterator<SegmentedContainerT> & it1,
+        const SegmentedContainerIterator<SegmentedContainerT> & it2) noexcept -> bool;
+
+    // hash function for shared pointers
+    // Note that two pointers pointing to the same cell collapse on the same hashed value
+    template <class sharedPointerT>
+    struct hash_function {
+        size_t operator()(const sharedPointerT & item) const
+        {
+            // reinterpret the address of the pointed handle as a {size_t} and return it
+            return reinterpret_cast<size_t>(item.id());
+        }
+    };
+}
+
+
+#endif
+
+// end of file

--- a/lib/mito/utilities/utilities.h
+++ b/lib/mito/utilities/utilities.h
@@ -4,18 +4,6 @@
 
 
 namespace mito::utilities {
-    // segmented container iterator equality
-    template <class SegmentedContainerT>
-    constexpr auto operator==(
-        const SegmentedContainerIterator<SegmentedContainerT> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT> & it2) noexcept -> bool;
-
-
-    // and inequality
-    template <class SegmentedContainerT>
-    constexpr auto operator!=(
-        const SegmentedContainerIterator<SegmentedContainerT> & it1,
-        const SegmentedContainerIterator<SegmentedContainerT> & it2) noexcept -> bool;
 
     // hash function for shared pointers
     // Note that two pointers pointing to the same cell collapse on the same hashed value

--- a/tests/mito.lib/erase-element/main.cc
+++ b/tests/mito.lib/erase-element/main.cc
@@ -69,7 +69,9 @@ TEST(EraseElement, TestEraseElementMesh)
     std::cout << "Erasing simplex..." << std::endl;
     mesh.erase(cell0);
     topology.erase(cell0);
-    // mesh.erase(cell0);
+    // check that erasing a cell twice does not result in an error
+    mesh.erase(cell0);
+    topology.erase(cell0);
 
     // std::cout << "After erase: " << std::endl;
     // for (const auto & simplex : mesh.cells<2>()) {
@@ -173,4 +175,7 @@ TEST(EraseElement, TestEraseElementTopology)
     // assert that a segment connecting vertex 2 and 3 no longer exists in the topology
     // ({segment_4} was erased because it is unused after erasing {cell_1})
     EXPECT_FALSE(topology.exists({ vertex_2, vertex_3 }));
+
+    // check that erasing a cell twice does not result in an error
+    topology.erase(cell_1);
 }

--- a/tests/mito.lib/erase-element/main.cc
+++ b/tests/mito.lib/erase-element/main.cc
@@ -28,12 +28,12 @@ TEST(EraseElement, TestEraseElementMesh)
     auto segment0 = topology.segment({ vertex0, vertex1 });
     auto segment1 = topology.segment({ vertex1, vertex3 });
     auto segment2 = topology.segment({ vertex3, vertex0 });
-    auto & cell0 = topology.triangle({ segment0, segment1, segment2 });
+    auto cell0 = topology.triangle({ segment0, segment1, segment2 });
 
     auto segment3 = topology.segment({ vertex1, vertex2 });
     auto segment4 = topology.segment({ vertex2, vertex3 });
     auto segment5 = topology.segment({ vertex3, vertex1 });
-    auto & cell1 = topology.triangle({ segment3, segment4, segment5 });
+    auto cell1 = topology.triangle({ segment3, segment4, segment5 });
 
     auto segment6 = topology.segment({ vertex2, vertex4 });
     auto segment7 = topology.segment({ vertex4, vertex3 });
@@ -134,8 +134,8 @@ TEST(EraseElement, TestEraseElementTopology)
     auto vertex_3 = topology.vertex();
     auto vertex_4 = topology.vertex();
 
-    auto & cell_0 = topology.triangle({ vertex_0, vertex_1, vertex_3 });
-    auto & cell_1 = topology.triangle({ vertex_1, vertex_2, vertex_3 });
+    auto cell_0 = topology.triangle({ vertex_0, vertex_1, vertex_3 });
+    auto cell_1 = topology.triangle({ vertex_1, vertex_2, vertex_3 });
     topology.triangle({ vertex_2, vertex_4, vertex_3 });
     topology.triangle({ vertex_4, vertex_0, vertex_3 });
 

--- a/tests/mito.lib/flip-diagonal/main.cc
+++ b/tests/mito.lib/flip-diagonal/main.cc
@@ -14,8 +14,8 @@ TEST(FlipDiagonal, TestFlipDiagonal)
     auto vertex3 = topology.vertex();
 
     // build triangles
-    auto & simplex0 = topology.triangle({ vertex0, vertex1, vertex2 });
-    auto & simplex1 = topology.triangle({ vertex0, vertex2, vertex3 });
+    auto simplex0 = topology.triangle({ vertex0, vertex1, vertex2 });
+    auto simplex1 = topology.triangle({ vertex0, vertex2, vertex3 });
 
     // build the two triangles obtained by flipping the common edge of the two triangles
     [[maybe_unused]] auto simplex_pair =
@@ -27,7 +27,7 @@ TEST(FlipDiagonal, TestFlipDiagonal)
 
     // assert that the new diagonal is now in use (by factory, driver, and two triangles)
     auto segment_f = topology.segment({ vertex1, vertex3 });
-    EXPECT_EQ(segment_f->footprint().references(), 3);
+    EXPECT_EQ(segment_f->footprint().references(), 2);
 
     // erase the old simplices
     topology.erase(simplex0);

--- a/tests/mito.lib/segmented-container-iterator/main.cc
+++ b/tests/mito.lib/segmented-container-iterator/main.cc
@@ -15,6 +15,7 @@ class Resource : public mito::utilities::Shareable {
 // the resource type
 using resource_t = mito::utilities::shared_ptr<Resource>;
 
+// TOFIX: these tests now really test Repository. Rename the tests
 TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
 {
     // instantiate a repository of {Resource} resources
@@ -30,8 +31,8 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
     auto simplex2 = collection.emplace(2);
 
     std::vector<int> store_elements;
-    for (const auto & el : collection.resources()) {
-        store_elements.emplace_back(el.foo());
+    for (const auto & el : collection) {
+        store_elements.emplace_back(el->foo());
     }
 
     EXPECT_EQ(store_elements[0], 0);
@@ -44,8 +45,8 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
     // erase element in the middle
     collection.erase(simplex1);
 
-    for (const auto & el : collection.resources()) {
-        store_elements.emplace_back(el.foo());
+    for (const auto & el : collection) {
+        store_elements.emplace_back(el->foo());
     }
 
     EXPECT_EQ(store_elements[0], 0);
@@ -57,8 +58,8 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
     // erase first element
     collection.erase(simplex0);
 
-    for (const auto & el : collection.resources()) {
-        store_elements.emplace_back(el.foo());
+    for (const auto & el : collection) {
+        store_elements.emplace_back(el->foo());
     }
 
     EXPECT_EQ(store_elements[0], 2);
@@ -83,8 +84,8 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
     // emplace another simplex (trigger allocation of new segment)
     auto simplex4 = collection.emplace(4);
 
-    for (const auto & el : collection.resources()) {
-        store_elements.emplace_back(el.foo());
+    for (const auto & el : collection) {
+        store_elements.emplace_back(el->foo());
     }
 
     // the order of the values depends on the order elimination of the previous simplices

--- a/tests/mito.lib/segmented-container-iterator/main.cc
+++ b/tests/mito.lib/segmented-container-iterator/main.cc
@@ -2,10 +2,9 @@
 #include <mito/base.h>
 #include <mito/utilities.h>
 
-// TOFIX: perhaps rename this to Resource to make it more general?
-class Simplex : public mito::utilities::Shareable {
+class Resource : public mito::utilities::Shareable {
   public:
-    Simplex(int foo) : _foo(foo) {}
+    Resource(int foo) : _foo(foo) {}
 
     int foo() const { return _foo; }
 
@@ -13,13 +12,13 @@ class Simplex : public mito::utilities::Shareable {
     int _foo;
 };
 
-// the simplex type
-using simplex_t = mito::utilities::shared_ptr<Simplex>;
+// the resource type
+using resource_t = mito::utilities::shared_ptr<Resource>;
 
 TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
 {
-    // instantiate a repository of {Simplex} resources
-    mito::utilities::repository_t<simplex_t> collection(3 /*segment size */);
+    // instantiate a repository of {Resource} resources
+    mito::utilities::repository_t<resource_t> collection(3 /*segment size */);
 
     // assert that the container is empty and with no capacity
     EXPECT_EQ(collection.resources().capacity(), 0);

--- a/tests/mito.lib/segmented-container-iterator/main.cc
+++ b/tests/mito.lib/segmented-container-iterator/main.cc
@@ -31,7 +31,7 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
 
     std::vector<int> store_elements;
     for (const auto & el : collection.resources()) {
-        store_elements.emplace_back(el->foo());
+        store_elements.emplace_back(el.foo());
     }
 
     EXPECT_EQ(store_elements[0], 0);
@@ -45,7 +45,7 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
     collection.erase(simplex1);
 
     for (const auto & el : collection.resources()) {
-        store_elements.emplace_back(el->foo());
+        store_elements.emplace_back(el.foo());
     }
 
     EXPECT_EQ(store_elements[0], 0);
@@ -58,7 +58,7 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
     collection.erase(simplex0);
 
     for (const auto & el : collection.resources()) {
-        store_elements.emplace_back(el->foo());
+        store_elements.emplace_back(el.foo());
     }
 
     EXPECT_EQ(store_elements[0], 2);
@@ -84,7 +84,7 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
     auto simplex4 = collection.emplace(4);
 
     for (const auto & el : collection.resources()) {
-        store_elements.emplace_back(el->foo());
+        store_elements.emplace_back(el.foo());
     }
 
     // the order of the values depends on the order elimination of the previous simplices

--- a/tests/mito.lib/segmented-container-iterator/main.cc
+++ b/tests/mito.lib/segmented-container-iterator/main.cc
@@ -70,6 +70,11 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
     // erase last element
     collection.erase(simplex2);
 
+    // loop on an empty repository
+    for (const auto & el : collection) {
+        store_elements.emplace_back(el->foo());
+    }
+
     EXPECT_EQ(std::size(store_elements), 0);
 
     store_elements.clear();

--- a/tests/mito.lib/segmented-container-iterator/main.cc
+++ b/tests/mito.lib/segmented-container-iterator/main.cc
@@ -2,6 +2,7 @@
 #include <mito/base.h>
 #include <mito/utilities.h>
 
+// TOFIX: perhaps rename this to Resource to make it more general?
 class Simplex : public mito::utilities::Shareable {
   public:
     Simplex(int foo) : _foo(foo) {}
@@ -12,16 +13,15 @@ class Simplex : public mito::utilities::Shareable {
     int _foo;
 };
 
-using simplex_t = mito::utilities::SharedPointer<Simplex>;
 
 TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
 {
-    // instantiate a segmented container
-    mito::utilities::segmented_t<simplex_t> collection(3 /*segment size */);
+    // instantiate a repository of {Simplex} resources
+    mito::utilities::repository_t<Simplex> collection(3 /*segment size */);
 
     // assert that the container is empty and with no capacity
-    EXPECT_EQ(collection.capacity(), 0);
-    EXPECT_EQ(std::size(collection), 0);
+    EXPECT_EQ(collection.resources().capacity(), 0);
+    EXPECT_EQ(std::size(collection.resources()), 0);
 
     // emplace three simplices in the container
     auto simplex0 = collection.emplace(0);
@@ -29,7 +29,7 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
     auto simplex2 = collection.emplace(2);
 
     std::vector<int> store_elements;
-    for (const auto & el : collection) {
+    for (const auto & el : collection.resources()) {
         store_elements.emplace_back(el->foo());
     }
 
@@ -40,10 +40,10 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
 
     store_elements.clear();
 
-    // invalidate element in the middle
-    simplex1.reset();
+    // erase element in the middle
+    collection.erase(simplex1);
 
-    for (const auto & el : collection) {
+    for (const auto & el : collection.resources()) {
         store_elements.emplace_back(el->foo());
     }
 
@@ -53,10 +53,10 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
 
     store_elements.clear();
 
-    // invalidate first element
-    simplex0.reset();
+    // erase first element
+    collection.erase(simplex0);
 
-    for (const auto & el : collection) {
+    for (const auto & el : collection.resources()) {
         store_elements.emplace_back(el->foo());
     }
 
@@ -65,8 +65,8 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
 
     store_elements.clear();
 
-    // invalidate last element
-    simplex2.reset();
+    // erase last element
+    collection.erase(simplex2);
 
     EXPECT_EQ(std::size(store_elements), 0);
 
@@ -82,7 +82,7 @@ TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
     // emplace another simplex (trigger allocation of new segment)
     auto simplex4 = collection.emplace(4);
 
-    for (const auto & el : collection) {
+    for (const auto & el : collection.resources()) {
         store_elements.emplace_back(el->foo());
     }
 

--- a/tests/mito.lib/segmented-container-iterator/main.cc
+++ b/tests/mito.lib/segmented-container-iterator/main.cc
@@ -13,11 +13,13 @@ class Simplex : public mito::utilities::Shareable {
     int _foo;
 };
 
+// the simplex type
+using simplex_t = mito::utilities::shared_ptr<Simplex>;
 
 TEST(SegmentedContainerIterator, TestSegmentedContainerIterator)
 {
     // instantiate a repository of {Simplex} resources
-    mito::utilities::repository_t<Simplex> collection(3 /*segment size */);
+    mito::utilities::repository_t<simplex_t> collection(3 /*segment size */);
 
     // assert that the container is empty and with no capacity
     EXPECT_EQ(collection.resources().capacity(), 0);

--- a/tests/mito.lib/segmented-container/main.cc
+++ b/tests/mito.lib/segmented-container/main.cc
@@ -2,6 +2,7 @@
 #include <mito/base.h>
 #include <mito/utilities.h>
 
+// TOFIX: perhaps rename this to Resource to make it more general?
 class Simplex : public mito::utilities::Shareable {
   public:
     Simplex(int foo) : _foo(foo) {}
@@ -10,62 +11,64 @@ class Simplex : public mito::utilities::Shareable {
     int _foo;
 };
 
-using simplex_t = mito::utilities::SharedPointer<Simplex>;
 
 TEST(SegmentedContainer, TestSegmentedContainer)
 {
     // segment size
     const auto segmentSize = 3;
 
-    // instantiate a segmented container
-    mito::utilities::segmented_t<simplex_t> collection(segmentSize);
+    // instantiate a repository of {Simplex} resources
+    mito::utilities::repository_t<Simplex> collection(segmentSize);
 
     // check segment size
-    EXPECT_EQ(collection.segment_size(), segmentSize);
+    EXPECT_EQ(collection.resources().segment_size(), segmentSize);
 
     // assert that the container is empty and with no capacity
-    EXPECT_EQ(collection.capacity(), 0);
-    EXPECT_EQ(std::size(collection), 0);
+    EXPECT_EQ(collection.resources().capacity(), 0);
+    EXPECT_EQ(std::size(collection.resources()), 0);
 
     // emplace three simplices in the container
     auto simplex0 = collection.emplace(0);
     auto simplex1 = collection.emplace(1);
 
     // assert that the container has 2 elements and its capacity is 3
-    EXPECT_EQ(collection.capacity(), 3);
-    EXPECT_EQ(std::size(collection), 2);
+    EXPECT_EQ(collection.resources().capacity(), 3);
+    EXPECT_EQ(std::size(collection.resources()), 2);
 
-    {
-        // emplace one simplex
-        auto simplex2 = collection.emplace(2);
+    // emplace one simplex
+    auto simplex2 = collection.emplace(2);
 
-        // assert that the container has 3 elements and its capacity is 3
-        EXPECT_EQ(collection.capacity(), 3);
-        EXPECT_EQ(std::size(collection), 3);
-    }
+    // assert that the container has 3 elements and its capacity is 3
+    EXPECT_EQ(collection.resources().capacity(), 3);
+    EXPECT_EQ(std::size(collection.resources()), 3);
+
+    // erase it
+    collection.erase(simplex2);
 
     // assert that the container has 2 elements and its capacity is still 3
-    EXPECT_EQ(collection.capacity(), 3);
-    EXPECT_EQ(std::size(collection), 2);
+    EXPECT_EQ(collection.resources().capacity(), 3);
+    EXPECT_EQ(std::size(collection.resources()), 2);
 
-    {
-        // emplace one simplex
-        auto simplex3 = collection.emplace(3);
+    // emplace one simplex
+    auto simplex3 = collection.emplace(3);
 
-        // assert that the container has again 3 elements and its capacity is 3
-        EXPECT_EQ(collection.capacity(), 3);
-        EXPECT_EQ(std::size(collection), 3);
+    // assert that the container has again 3 elements and its capacity is 3
+    EXPECT_EQ(collection.resources().capacity(), 3);
+    EXPECT_EQ(std::size(collection.resources()), 3);
 
-        // emplace another simplex (trigger allocation of new segment)
-        auto simplex4 = collection.emplace(4);
+    // emplace another simplex (trigger allocation of new segment)
+    auto simplex4 = collection.emplace(4);
 
-        // assert that the container has now 4 elements and its capacity is 6
-        // (new memory allocation was in fact triggered)
-        EXPECT_EQ(collection.capacity(), 6);
-        EXPECT_EQ(std::size(collection), 4);
-    }
+    // assert that the container has now 4 elements and its capacity is 6
+    // (new memory allocation was in fact triggered)
+    EXPECT_EQ(collection.resources().capacity(), 6);
+    EXPECT_EQ(std::size(collection.resources()), 4);
+
+    // erase more simplices
+    collection.erase(simplex3);
+    collection.erase(simplex4);
 
     // assert that the container has now 2 elements but has still capacity of 6
-    EXPECT_EQ(collection.capacity(), 6);
-    EXPECT_EQ(std::size(collection), 2);
+    EXPECT_EQ(collection.resources().capacity(), 6);
+    EXPECT_EQ(std::size(collection.resources()), 2);
 }

--- a/tests/mito.lib/segmented-container/main.cc
+++ b/tests/mito.lib/segmented-container/main.cc
@@ -2,25 +2,24 @@
 #include <mito/base.h>
 #include <mito/utilities.h>
 
-// TOFIX: perhaps rename this to Resource to make it more general?
-class Simplex : public mito::utilities::Shareable {
+class Resource : public mito::utilities::Shareable {
   public:
-    Simplex(int foo) : _foo(foo) {}
+    Resource(int foo) : _foo(foo) {}
 
   private:
     int _foo;
 };
 
-// the simplex type
-using simplex_t = mito::utilities::shared_ptr<Simplex>;
+// the resource type
+using resource_t = mito::utilities::shared_ptr<Resource>;
 
 TEST(SegmentedContainer, TestSegmentedContainer)
 {
     // segment size
     const auto segmentSize = 3;
 
-    // instantiate a repository of {simplex_t} resources
-    mito::utilities::repository_t<simplex_t> collection(segmentSize);
+    // instantiate a repository of {resource_t} resources
+    mito::utilities::repository_t<resource_t> collection(segmentSize);
 
     // check segment size
     EXPECT_EQ(collection.resources().segment_size(), segmentSize);

--- a/tests/mito.lib/segmented-container/main.cc
+++ b/tests/mito.lib/segmented-container/main.cc
@@ -11,14 +11,16 @@ class Simplex : public mito::utilities::Shareable {
     int _foo;
 };
 
+// the simplex type
+using simplex_t = mito::utilities::shared_ptr<Simplex>;
 
 TEST(SegmentedContainer, TestSegmentedContainer)
 {
     // segment size
     const auto segmentSize = 3;
 
-    // instantiate a repository of {Simplex} resources
-    mito::utilities::repository_t<Simplex> collection(segmentSize);
+    // instantiate a repository of {simplex_t} resources
+    mito::utilities::repository_t<simplex_t> collection(segmentSize);
 
     // check segment size
     EXPECT_EQ(collection.resources().segment_size(), segmentSize);

--- a/tests/mito.lib/shared-pointer/main.cc
+++ b/tests/mito.lib/shared-pointer/main.cc
@@ -19,7 +19,7 @@ TEST(SharedPointer, DefaultConstructor)
 {
     auto std_shared_ptr1 = std::make_shared<int>(1);
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1), nullptr);
+    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
 
     EXPECT_EQ(shared_ptr1.references(), std_shared_ptr1.use_count());
 }
@@ -29,7 +29,7 @@ TEST(SharedPointer, CopyConstructor)
     auto std_shared_ptr1 = std::make_shared<int>(1);
     std::shared_ptr<int> std_shared_ptr2 = std_shared_ptr1;
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1), nullptr);
+    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
     mito::utilities::SharedPointer<resource_t> shared_ptr2 = shared_ptr1;
 
     EXPECT_EQ(shared_ptr1.references(), std_shared_ptr1.use_count());
@@ -41,7 +41,7 @@ TEST(SharedPointer, MoveConstructor)
     auto std_shared_ptr1 = std::make_shared<int>(1);
     std::shared_ptr<int> std_shared_ptr2(std::move(std_shared_ptr1));
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1), nullptr);
+    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
     mito::utilities::SharedPointer<resource_t> shared_ptr2(std::move(shared_ptr1));
 
     EXPECT_EQ(shared_ptr2.references(), std_shared_ptr2.use_count());
@@ -53,8 +53,8 @@ TEST(SharedPointer, AssignmentOperator)
     auto std_shared_ptr2 = std::make_shared<int>(1);
     std_shared_ptr2 = std_shared_ptr1;
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1), nullptr);
-    mito::utilities::SharedPointer<resource_t> shared_ptr2(new resource_t(1), nullptr);
+    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
+    mito::utilities::SharedPointer<resource_t> shared_ptr2(new resource_t(1));
     shared_ptr2 = shared_ptr1;
 
     EXPECT_EQ(shared_ptr1.references(), std_shared_ptr1.use_count());
@@ -67,8 +67,8 @@ TEST(SharedPointer, MoveAssignmentOperator)
     auto std_shared_ptr2 = std::make_shared<int>(1);
     std_shared_ptr2 = std::move(std_shared_ptr1);
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1), nullptr);
-    mito::utilities::SharedPointer<resource_t> shared_ptr2(new resource_t(1), nullptr);
+    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
+    mito::utilities::SharedPointer<resource_t> shared_ptr2(new resource_t(1));
     shared_ptr2 = std::move(shared_ptr1);
 
     EXPECT_EQ(shared_ptr2.references(), std_shared_ptr2.use_count());
@@ -81,9 +81,9 @@ TEST(SharedPointer, ThreeWayAssignment)
     auto std_shared_ptr3 = std::make_shared<int>(1);
     std_shared_ptr2 = std_shared_ptr3;
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1), nullptr);
+    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
     mito::utilities::SharedPointer<resource_t> shared_ptr2 = shared_ptr1;
-    mito::utilities::SharedPointer<resource_t> shared_ptr3(new resource_t(1), nullptr);
+    mito::utilities::SharedPointer<resource_t> shared_ptr3(new resource_t(1));
     shared_ptr2 = shared_ptr3;
 
     EXPECT_EQ(shared_ptr1.references(), std_shared_ptr1.use_count());
@@ -101,7 +101,7 @@ TEST(SharedPointer, Destructor)
 
     mito::utilities::SharedPointer<resource_t> shared_ptr2;
     {
-        mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1), nullptr);
+        mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
         shared_ptr2 = shared_ptr1;
     }
 
@@ -147,7 +147,7 @@ TEST(SharedPointer, TestSegmentAllocation)
 
     // instantiate new resource at {location}
     resource_t * resource = new (location) resource_t(a);
-    mito::utilities::shared_ptr<resource_t> handle(resource, nullptr);
+    mito::utilities::shared_ptr<resource_t> handle(resource);
 
     // modify the resource
     handle->_a += 1;

--- a/tests/mito.lib/shared-pointer/main.cc
+++ b/tests/mito.lib/shared-pointer/main.cc
@@ -14,12 +14,13 @@ class Resource : public mito::utilities::Shareable {
 
 // the type of resource to be stored
 using resource_t = Resource;
+using shared_ptr_t = mito::utilities::shared_ptr<resource_t>;
 
 TEST(SharedPointer, DefaultConstructor)
 {
     auto std_shared_ptr1 = std::make_shared<int>(1);
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
+    shared_ptr_t shared_ptr1(new resource_t(1));
 
     EXPECT_EQ(shared_ptr1.references(), std_shared_ptr1.use_count());
 }
@@ -29,8 +30,8 @@ TEST(SharedPointer, CopyConstructor)
     auto std_shared_ptr1 = std::make_shared<int>(1);
     std::shared_ptr<int> std_shared_ptr2 = std_shared_ptr1;
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
-    mito::utilities::SharedPointer<resource_t> shared_ptr2 = shared_ptr1;
+    shared_ptr_t shared_ptr1(new resource_t(1));
+    shared_ptr_t shared_ptr2 = shared_ptr1;
 
     EXPECT_EQ(shared_ptr1.references(), std_shared_ptr1.use_count());
     EXPECT_EQ(shared_ptr2.references(), std_shared_ptr2.use_count());
@@ -41,8 +42,8 @@ TEST(SharedPointer, MoveConstructor)
     auto std_shared_ptr1 = std::make_shared<int>(1);
     std::shared_ptr<int> std_shared_ptr2(std::move(std_shared_ptr1));
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
-    mito::utilities::SharedPointer<resource_t> shared_ptr2(std::move(shared_ptr1));
+    shared_ptr_t shared_ptr1(new resource_t(1));
+    shared_ptr_t shared_ptr2(std::move(shared_ptr1));
 
     EXPECT_EQ(shared_ptr2.references(), std_shared_ptr2.use_count());
 }
@@ -53,8 +54,8 @@ TEST(SharedPointer, AssignmentOperator)
     auto std_shared_ptr2 = std::make_shared<int>(1);
     std_shared_ptr2 = std_shared_ptr1;
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
-    mito::utilities::SharedPointer<resource_t> shared_ptr2(new resource_t(1));
+    shared_ptr_t shared_ptr1(new resource_t(1));
+    shared_ptr_t shared_ptr2(new resource_t(1));
     shared_ptr2 = shared_ptr1;
 
     EXPECT_EQ(shared_ptr1.references(), std_shared_ptr1.use_count());
@@ -67,8 +68,8 @@ TEST(SharedPointer, MoveAssignmentOperator)
     auto std_shared_ptr2 = std::make_shared<int>(1);
     std_shared_ptr2 = std::move(std_shared_ptr1);
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
-    mito::utilities::SharedPointer<resource_t> shared_ptr2(new resource_t(1));
+    shared_ptr_t shared_ptr1(new resource_t(1));
+    shared_ptr_t shared_ptr2(new resource_t(1));
     shared_ptr2 = std::move(shared_ptr1);
 
     EXPECT_EQ(shared_ptr2.references(), std_shared_ptr2.use_count());
@@ -81,9 +82,9 @@ TEST(SharedPointer, ThreeWayAssignment)
     auto std_shared_ptr3 = std::make_shared<int>(1);
     std_shared_ptr2 = std_shared_ptr3;
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
-    mito::utilities::SharedPointer<resource_t> shared_ptr2 = shared_ptr1;
-    mito::utilities::SharedPointer<resource_t> shared_ptr3(new resource_t(1));
+    shared_ptr_t shared_ptr1(new resource_t(1));
+    shared_ptr_t shared_ptr2 = shared_ptr1;
+    shared_ptr_t shared_ptr3(new resource_t(1));
     shared_ptr2 = shared_ptr3;
 
     EXPECT_EQ(shared_ptr1.references(), std_shared_ptr1.use_count());
@@ -99,9 +100,9 @@ TEST(SharedPointer, Destructor)
         std_shared_ptr2 = std_shared_ptr1;
     }
 
-    mito::utilities::SharedPointer<resource_t> shared_ptr2;
+    shared_ptr_t shared_ptr2;
     {
-        mito::utilities::SharedPointer<resource_t> shared_ptr1(new resource_t(1));
+        shared_ptr_t shared_ptr1(new resource_t(1));
         shared_ptr2 = shared_ptr1;
     }
 

--- a/tests/mito.lib/simplices/main.cc
+++ b/tests/mito.lib/simplices/main.cc
@@ -38,14 +38,14 @@ TEST(Simplices, TestSimplices)
     // assert there is only one segment connecting {vertex0} and {vertex1}
     EXPECT_FALSE(topology.exists_flipped(segment0));
     // assert no simplex rides on this segment yet
-    EXPECT_EQ(segment0.references(), 2);
+    EXPECT_EQ(segment0.references(), 1);
 
     // build a segment connecting {vertex1} and {vertex3}
     auto segment1 = topology.segment({ vertex1, vertex3 });
     // assert there is only one segment connecting {vertex1} and {vertex3}
     EXPECT_FALSE(topology.exists_flipped(segment1));
     // assert no simplex rides on this segment yet
-    EXPECT_EQ(segment1.references(), 2);
+    EXPECT_EQ(segment1.references(), 1);
 
     // build the flipped segment connecting {vertex1} and {vertex3}
     auto segment1m = topology.flip(segment1);
@@ -53,30 +53,30 @@ TEST(Simplices, TestSimplices)
     EXPECT_TRUE(topology.exists_flipped(segment1));
     EXPECT_TRUE(topology.exists_flipped(segment1m));
     // assert no simplex rides on this segment yet
-    EXPECT_EQ(segment1.references(), 2);
+    EXPECT_EQ(segment1.references(), 1);
     // assert no simplex rides on this segment yet
-    EXPECT_EQ(segment1m.references(), 2);
+    EXPECT_EQ(segment1m.references(), 1);
 
     // build a segment connecting {vertex3} and {vertex0}
     auto segment2 = topology.segment({ vertex3, vertex0 });
     // assert there is only one segment connecting {vertex3} and {vertex0}
     EXPECT_FALSE(topology.exists_flipped(segment2));
     // assert no simplex rides on this segment yet
-    EXPECT_EQ(segment2.references(), 2);
+    EXPECT_EQ(segment2.references(), 1);
 
     // build a segment connecting {vertex1} and {vertex2}
     auto segment3 = topology.segment({ vertex1, vertex2 });
     // assert there is only one segment connecting {vertex1} and {vertex2}
     EXPECT_FALSE(topology.exists_flipped(segment3));
     // assert no simplex rides on this segment yet
-    EXPECT_EQ(segment3.references(), 2);
+    EXPECT_EQ(segment3.references(), 1);
 
     // build a segment connecting {vertex2} and {vertex3}
     auto segment4 = topology.segment({ vertex2, vertex3 });
     // assert there is only one segment connecting {vertex2} and {vertex3}
     EXPECT_FALSE(topology.exists_flipped(segment4));
     // assert no simplex rides on this segment yet
-    EXPECT_EQ(segment4.references(), 2);
+    EXPECT_EQ(segment4.references(), 1);
 
     // build a triangle connecting {segment0}, {segment1}, and {segment2}
     auto cell0 = topology.triangle({ segment0, segment1, segment2 });
@@ -84,18 +84,18 @@ TEST(Simplices, TestSimplices)
     std::cout << cell0 << std::endl;
 
     // assert there is one simplex riding on this segment (cell0)
-    EXPECT_EQ(segment0.references(), 3);
+    EXPECT_EQ(segment0.references(), 2);
     // assert there is one simplex riding on this segment (cell0)
-    EXPECT_EQ(segment1.references(), 3);
+    EXPECT_EQ(segment1.references(), 2);
     // assert no simplex rides on this segment yet
-    EXPECT_EQ(segment1m.references(), 2);
+    EXPECT_EQ(segment1m.references(), 1);
     // assert there is one simplex riding on this segment (cell0)
-    EXPECT_EQ(segment2.references(), 3);
+    EXPECT_EQ(segment2.references(), 2);
 
     // assert there is one triangle connecting {segment0}, {segment1}, and {segment2}
     EXPECT_FALSE(topology.exists_flipped(cell0));
     // assert no simplex rides on this segment
-    EXPECT_EQ(cell0.references(), 2);
+    EXPECT_EQ(cell0.references(), 1);
 
     // build a triangle connecting {segment3}, {segment4}, and {segment1m}
     auto cell1 = topology.triangle({ segment3, segment4, segment1m });
@@ -103,16 +103,16 @@ TEST(Simplices, TestSimplices)
     std::cout << cell1 << std::endl;
 
     // assert there is one simplex riding on this segment (cell1)
-    EXPECT_EQ(segment3.references(), 3);
+    EXPECT_EQ(segment3.references(), 2);
     // assert there is one simplex riding on this segment (cell1)
-    EXPECT_EQ(segment4.references(), 3);
+    EXPECT_EQ(segment4.references(), 2);
     // assert there is one simplex riding on this segment (cell1)
-    EXPECT_EQ(segment1m.references(), 3);
+    EXPECT_EQ(segment1m.references(), 2);
 
     // assert there is one triangle connecting {segment3}, {segment4}, and {segment1m}
     EXPECT_FALSE(topology.exists_flipped(cell1));
     // assert no simplex rides on this segment
-    EXPECT_EQ(cell1.references(), 2);
+    EXPECT_EQ(cell1.references(), 1);
 
     // sanity check
     for (const auto & e : { cell0, cell1 }) {


### PR DESCRIPTION
Added the concept of `Repository` as a centralized data structure where shareable resources are stored. This layer allows to factor a good amount of code out of the factory classes (e.g. `SimplexFactory`, `PointCloud`, ...). In addition, it allows the `SegmentedContainer` class to be decoupled from the concept of shareable resource, which makes its implementation more general.