### PR TITLE
Improve management of rvalue references and universal references

### DIFF
--- a/lib/mito/geometry/Coordinates.h
+++ b/lib/mito/geometry/Coordinates.h
@@ -51,7 +51,7 @@ namespace mito::geometry {
         constexpr Coordinates() : _array() {}
 
         // constructor
-        constexpr Coordinates(const mito::scalar_t (&&coords)[D]) : _array(coords) {}
+        constexpr Coordinates(mito::scalar_t (&&coords)[D]) : _array(std::move(coords)) {}
 
         // constructor
         constexpr Coordinates(const array_t coords) : _array(coords) {}

--- a/lib/mito/geometry/factories.h
+++ b/lib/mito/geometry/factories.h
@@ -7,9 +7,9 @@ namespace mito::geometry {
 
     // factory for coordinates from brace-enclosed initializer list
     template <CoordinateType coordT = EUCLIDEAN, int D>
-    constexpr auto coordinates(const mito::scalar_t (&&coords)[D])
+    constexpr auto coordinates(mito::scalar_t (&&coords)[D])
     {
-        return coordinates_t<D, coordT>(coords);
+        return coordinates_t<D, coordT>(std::move(coords));
     }
 
     // factory for coordinate system

--- a/lib/mito/manifolds/Field.h
+++ b/lib/mito/manifolds/Field.h
@@ -29,7 +29,7 @@ namespace mito::manifolds {
 
       public:
         // constructor
-        constexpr Field(F f) : _f{ f } {}
+        constexpr Field(F f) : _f{ std::move(f) } {}
 
         // the value of the field at position {x}
         constexpr auto operator()(const coordinates_type & x) const -> output_type { return _f(x); }

--- a/lib/mito/manifolds/Form.h
+++ b/lib/mito/manifolds/Form.h
@@ -25,7 +25,7 @@ namespace mito::manifolds {
 
       public:
         // constructor
-        constexpr Form(F f) : _f{ f } {}
+        constexpr Form(F f) : _f{ std::move(f) } {}
 
         // contraction operator
         template <typename... argsT>

--- a/lib/mito/manifolds/factories.h
+++ b/lib/mito/manifolds/factories.h
@@ -19,14 +19,14 @@ namespace mito::manifolds {
     template <class F>
     constexpr auto one_form(F && f) -> one_form_t<F>
     {
-        return one_form_t<F>(f);
+        return one_form_t<F>(std::forward<F>(f));
     }
 
     // factory for P-forms
     template <int P, class F>
     constexpr auto form(F && f) -> form_t<P, F>
     {
-        return form_t<P, F>(f);
+        return form_t<P, F>(std::forward<F>(f));
     }
 
     // construct a one-form based on its metric-equivalent vector (case: symmetric metric)
@@ -58,7 +58,7 @@ namespace mito::manifolds {
     template <class F>
     constexpr auto field(F && f) -> mito::manifolds::field_t<F>
     {
-        return mito::manifolds::field_t<F>(f);
+        return mito::manifolds::field_t<F>(std::forward<F>(f));
     }
 
     // construct a one-form based on its metric-equivalent vector field

--- a/lib/mito/math/factories.h
+++ b/lib/mito/math/factories.h
@@ -23,7 +23,7 @@ namespace mito::math {
     template <class F>
     constexpr auto function(F && f)
     {
-        return function_t<F>(f);
+        return function_t<F>(std::forward<F>(f));
     }
 
     // TOFIX: do we need this?

--- a/lib/mito/mesh/Mesh.h
+++ b/lib/mito/mesh/Mesh.h
@@ -48,7 +48,7 @@ namespace mito::mesh {
             : _geometry(geometry), _cells()
         {}
 
-        inline ~Mesh() {}
+        inline ~Mesh() = default;
 
         // move constructor
         inline Mesh(Mesh &&) noexcept = default;

--- a/lib/mito/quadrature/QuadratureTable.h
+++ b/lib/mito/quadrature/QuadratureTable.h
@@ -24,7 +24,7 @@ namespace mito::quadrature {
 
       public:
         // constructor
-        constexpr Table(array_type && pairs) : _table{ pairs } {}
+        constexpr Table(array_type && pairs) noexcept : _table{ std::move(pairs) } {}
 
         // the number of entries in the table (i.e. the pairings in the table)
         constexpr auto size() const -> int { return Q; }

--- a/lib/mito/simulation/Context.h
+++ b/lib/mito/simulation/Context.h
@@ -20,7 +20,7 @@ namespace mito::simulation {
 
       private:
         // delete move constructor
-        Context(context_type &&) = delete;
+        Context(context_type &&) noexcept = delete;
 
         // delete copy constructor
         Context(const context_type &) = delete;
@@ -29,7 +29,7 @@ namespace mito::simulation {
         Context & operator=(const context_type &) = delete;
 
         // delete move assignment operator
-        Context & operator=(context_type &&) = delete;
+        Context & operator=(context_type &&) noexcept = delete;
 
       public:
         // accessor for my process' rank

--- a/lib/mito/simulation/Simulation.h
+++ b/lib/mito/simulation/Simulation.h
@@ -24,7 +24,7 @@ namespace mito::simulation {
 
       private:
         // delete move constructor
-        Simulation(simulation_type &&) = delete;
+        Simulation(simulation_type &&) noexcept = delete;
 
         // delete copy constructor
         Simulation(const simulation_type &) = delete;
@@ -33,7 +33,7 @@ namespace mito::simulation {
         Simulation & operator=(const simulation_type &) = delete;
 
         // delete move assignment operator
-        Simulation & operator=(simulation_type &&) = delete;
+        Simulation & operator=(simulation_type &&) noexcept = delete;
 
       public:
         // accessor for the simulation execution context

--- a/lib/mito/topology/OrientedSimplex.h
+++ b/lib/mito/topology/OrientedSimplex.h
@@ -51,13 +51,13 @@ namespace mito::topology {
         OrientedSimplex(const OrientedSimplex &) = delete;
 
         // delete move constructor
-        OrientedSimplex(OrientedSimplex &&) = delete;
+        OrientedSimplex(OrientedSimplex &&) noexcept = delete;
 
         // delete assignment operator
         OrientedSimplex & operator=(const OrientedSimplex &) = delete;
 
         // delete move assignment operator
-        OrientedSimplex & operator=(OrientedSimplex &&) = delete;
+        OrientedSimplex & operator=(OrientedSimplex &&) noexcept = delete;
 
       public:
         // accessor for the unoriented footprint

--- a/lib/mito/topology/Simplex.h
+++ b/lib/mito/topology/Simplex.h
@@ -23,7 +23,9 @@ namespace mito::topology {
         constexpr Simplex(const simplex_composition_t<N> & simplices) : _simplices(simplices) {}
 
         // constructor for a simplex based on its composition in terms of subsimplices
-        constexpr Simplex(simplex_composition_t<N> && simplices) : _simplices(simplices) {}
+        constexpr Simplex(simplex_composition_t<N> && simplices) noexcept :
+            _simplices(std::move(simplices))
+        {}
 
         // destructor
         constexpr ~Simplex() override {}

--- a/lib/mito/topology/Simplex.h
+++ b/lib/mito/topology/Simplex.h
@@ -38,13 +38,13 @@ namespace mito::topology {
         Simplex(const Simplex &) = delete;
 
         // delete move constructor
-        Simplex(Simplex &&) = delete;
+        Simplex(Simplex &&) noexcept = delete;
 
         // delete assignment operator
         Simplex & operator=(const Simplex &) = delete;
 
         // delete move assignment operator
-        Simplex & operator=(Simplex &&) = delete;
+        Simplex & operator=(Simplex &&) noexcept = delete;
 
       public:
         // accessor for the subsimplices
@@ -207,13 +207,13 @@ namespace mito::topology {
         Simplex(const Simplex &) = delete;
 
         // delete move constructor
-        Simplex(Simplex &&) = delete;
+        Simplex(Simplex &&) noexcept = delete;
 
         // delete assignment operator
         Simplex & operator=(const Simplex &) = delete;
 
         // delete move assignment operator
-        Simplex & operator=(Simplex &&) = delete;
+        Simplex & operator=(Simplex &&) noexcept = delete;
 
       public:
         // perform a sanity check

--- a/lib/mito/utilities/Repository.h
+++ b/lib/mito/utilities/Repository.h
@@ -80,7 +80,7 @@ namespace mito::utilities {
             auto location = _resources.location_for_placement();
 
             // create a new instance of {resource_t} at location {location} with placement new
-            resource_t * resource = new (location) resource_t(args...);
+            resource_t * resource = new (location) resource_t(std::forward<Args>(args)...);
 
             // add resource to the collection of resources
             _resources.insert(resource);

--- a/lib/mito/utilities/SegmentedContainer.h
+++ b/lib/mito/utilities/SegmentedContainer.h
@@ -245,13 +245,13 @@ namespace mito::utilities {
         SegmentedContainer(const SegmentedContainer &) = delete;
 
         // delete move constructor
-        SegmentedContainer(SegmentedContainer &&) = delete;
+        SegmentedContainer(SegmentedContainer &&) noexcept = delete;
 
         // delete assignment operator
         SegmentedContainer & operator=(const SegmentedContainer &) = delete;
 
         // delete move assignment operator
-        SegmentedContainer & operator=(SegmentedContainer &&) = delete;
+        SegmentedContainer & operator=(SegmentedContainer &&) noexcept = delete;
 
         // the segment size
         const int _segment_size;

--- a/lib/mito/utilities/Shareable.h
+++ b/lib/mito/utilities/Shareable.h
@@ -29,14 +29,14 @@ namespace mito::utilities {
         inline Shareable(Shareable &) = delete;
 
         // move constructor
-        inline Shareable(Shareable &&) = delete;
+        inline Shareable(Shareable &&) noexcept = delete;
 
         // assignment operator
         inline Shareable & operator=(const Shareable &) = delete;
         inline Shareable & operator=(Shareable &) = delete;
 
         // move assignment operator
-        inline Shareable & operator=(Shareable &&) = delete;
+        inline Shareable & operator=(Shareable &&) noexcept = delete;
 
       private:
         // accessor for the number of outstanding references

--- a/lib/mito/utilities/SharedPointer.h
+++ b/lib/mito/utilities/SharedPointer.h
@@ -57,7 +57,7 @@ namespace mito::utilities {
         inline shared_ptr_type & operator=(const shared_ptr_type &);
 
         // move assignment operator
-        inline shared_ptr_type & operator=(shared_ptr_type &&);
+        inline shared_ptr_type & operator=(shared_ptr_type &&) noexcept;
 
       private:
         // accessor for {handle}

--- a/lib/mito/utilities/SharedPointer.icc
+++ b/lib/mito/utilities/SharedPointer.icc
@@ -116,7 +116,7 @@ mito::utilities::SharedPointer<resourceT>::SharedPointer(
 template <class resourceT>
 mito::utilities::SharedPointer<resourceT>::SharedPointer(
     mito::utilities::SharedPointer<resourceT> && other) noexcept :
-    _handle(other._handle)
+    _handle(std::move(other._handle))
 {
     // invalidate other
     other._handle = nullptr;
@@ -153,7 +153,7 @@ mito::utilities::SharedPointer<resourceT>::operator=(
         // release my current handle
         _release();
         // adopt the new shareable
-        _handle = other._handle;
+        _handle = std::move(other._handle);
     }
 
     // invalidate {other}

--- a/lib/mito/utilities/SharedPointer.icc
+++ b/lib/mito/utilities/SharedPointer.icc
@@ -146,7 +146,7 @@ mito::utilities::SharedPointer<resourceT>::operator=(
 template <class resourceT>
 mito::utilities::SharedPointer<resourceT> &
 mito::utilities::SharedPointer<resourceT>::operator=(
-    mito::utilities::SharedPointer<resourceT> && other)
+    mito::utilities::SharedPointer<resourceT> && other) noexcept
 {
     // if {other} and I point to different handles
     if (other._handle != _handle) {

--- a/lib/mito/utilities/Singleton.h
+++ b/lib/mito/utilities/Singleton.h
@@ -14,7 +14,7 @@ namespace mito::utilities {
         template <class... Args>
         static auto GetInstance(Args &&... args) -> resource_t &
         {
-            static resource_t resource(args...);
+            static resource_t resource(std::forward<Args>(args)...);
             return resource;
         }
 


### PR DESCRIPTION
- Applied `std::move` to rvalue references.
- Applied `std::foward` to universal references.
- Other minor improvements.