### PR TITLE
Fix github workflow

### DIFF
--- a/.github/workflows/cmake-macos.yaml
+++ b/.github/workflows/cmake-macos.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip3 install distro numpy pybind11 pytest vtk
+          pip3 install distro 'numpy<2.0' pybind11 pytest vtk
 
       - name: checkout gtest
         uses: actions/checkout@v3

--- a/.github/workflows/cmake-ubuntu.yaml
+++ b/.github/workflows/cmake-ubuntu.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip3 install distro numpy pybind11 pytest vtk
+          pip3 install distro 'numpy<2.0' pybind11 pytest vtk
 
       - name: checkout pyre
         uses: actions/checkout@v3


### PR DESCRIPTION
.github/workflows: temporarily restricted {numpy} under {2.0} until its relocated headers can be handled gracefully.