### PR TITLE
Version check

### DIFF
--- a/.cmake/mito_mito.cmake
+++ b/.cmake/mito_mito.cmake
@@ -51,7 +51,13 @@ function(mito_mitoLib)
         DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib/mito
         DESTINATION ${MITO_DEST_INCLUDE}
         FILES_MATCHING PATTERN *.h PATTERN *.icc
-        PATTERN version.cc
+    )
+
+    # install the mito version files
+    install(
+        DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/mito
+        DESTINATION ${MITO_DEST_INCLUDE}
+        FILES_MATCHING PATTERN version.cc PATTERN version.h
     )
 
     # libmito

--- a/lib/mito/version.cc.in
+++ b/lib/mito/version.cc.in
@@ -7,10 +7,11 @@
 #include "version.h"
 
 // build and return the version tuple
-mito::version_t
-mito::version() {
-    //
-    return version_t { @MAJOR@, @MINOR@, @MICRO@, "@REVISION@" };
+auto
+mito::version::version() -> version_t
+{
+    // easy enough
+    return version_t { major, minor, micro, revision };
 }
 
 // end of file

--- a/lib/mito/version.h.in
+++ b/lib/mito/version.h.in
@@ -11,14 +11,31 @@
 #include <tuple>
 #include <string>
 
-// my declarations
-namespace mito {
-    // my version is an array of three integers and the git hash
-    using version_t = std::tuple<int, int, int, std::string>;
 
-    // access to the version number of the {mito} library
-    version_t version();
-}
+// put all version related symbols in their own namespace
+// N.B.: version information is made available two different ways in order to enable detecting
+// inconsistencies between the headers accessible at compile time and the library available
+// at run time
+namespace mito::version {
+
+    // type aliases
+    using string_t = std::string;
+
+    // my version is a tuple of three integers and the {git} hash
+    using version_t = std::tuple<int, int, int, string_t>;
+
+    // the version of the {mito} library
+    auto version() -> version_t;
+
+    // the version visible through the headers
+    // clang-format off
+    const int major = @MAJOR@;
+    const int minor = @MINOR@;
+    const int micro = @MICRO@;
+    const string_t revision = "@REVISION@";
+    // clang-format on
+
+}    // namespace mito::version
 
 
 // end of file


### PR DESCRIPTION
The {version} information is now available both at compile time and runtime to enable the detection of broken installations.